### PR TITLE
Feature/effects and related modifiers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ package
 build
 package-lock.json
 Notes.md
+TODO.md

--- a/ModCreatorReadme.md
+++ b/ModCreatorReadme.md
@@ -171,7 +171,35 @@ if (mod.api.customModifiersInMelvor) {
 Just check `initApiEndpoints` in the `setup.ts` file to see exact type definition for the methods you want to call*
 
 
-# Working with monster types
+### Checking type during combat
+While we are on the topic of API calls - while documentation below will also inform you of a way to check type allocation for a monster,
+during combat there are two main checks to be aware of.
+
+Organic type allocation is applied on spawm, as easily checkable properties on the character object.
+This is qicker than always checking collections in the background.
+```js
+// Structure
+character.isTYPE
+
+// Example
+if(game.combat.player.target.isHuman) {
+  // Do stuff
+}
+```
+
+Artificial type allocation (aka "trait") is applied through modifiers, and are therefore checked as you would expect from any other modifier.
+That being said, depending on what you are implementing, artificial type allocation might not be a valid condition.
+```js
+// Structure
+character.modifiers.TYPETraitApplied
+
+// Example
+if(game.combat.player.target.modifiers.humanTraitApplied > 0) {
+  // Do stuff
+}
+```
+
+# Working with monster type definition
 The previous section should have given you a rough idea about the modifiers you can expect and how to work with them.
 However, what if you want to add additional monster type definitions based on your mod?
 
@@ -180,7 +208,8 @@ Active types are those that at least one mod actually makes use of (e.g. using t
 whereas inactive types are those that get defined, but actually end up not being used by any of the loaded mods.
 The reason for this difference is to avoid blurting the combat calculations with unnecessary processing.
 
-With that out of the way, this mod provides multiple API endpoints that you can utilize.
+With that out of the way, this mod provides multiple API endpoints that you can utilize. 
+One thing of note, you don't have to worry about expansions purchased by the user, when utilizing these endpoints.
 
 ```ts
 // Structure
@@ -229,7 +258,7 @@ addMonsters("Dragon", ["runescapeEncountersInMelvor:Gorvek_And_Vindicta"]);
 * @param active - whether the type should be set to active - as a mod consuming the api, this is basically always going to be true, but can technically be set to false as well
 * @returns void
 */
-registerOrUpdateType(typeNameSingular: string, typeNamePlural: string, iconResourceUrl: string, monsterIds: string[])
+registerOrUpdateType(typeNameSingular: string, typeNamePlural: string, iconResourceUrl: string, monsterIds: string[], active: Boolean)
 
 // Example
 registerOrUpdateType("Dragon", "Dragons", "https://cdn.melvor.net/core/v018/assets/media/monsters/dragon_green.png", ["runescapeEncountersInMelvor:Gorvek_And_Vindicta"]);

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ To do so, just check whether the api object is defined, and call the type-regist
 ```js
 if(mod.api.customModifiersInMelvor) {
 	// If you only add one monster, make sure you still provide an array and not just a string accidentally
-	mod.api.customModifiersInMelvor.addHumans(["MOD_NAMESPACE:MONSTER_ID", "MOD_NAMESPACE:MONSTER_ID", "..."]);
-	mod.api.customModifiersInMelvor.addDragons(["MOD_NAMESPACE:MONSTER_ID", "MOD_NAMESPACE:MONSTER_ID", "..."]);
-	mod.api.customModifiersInMelvor.addUndead(["MOD_NAMESPACE:MONSTER_ID", "MOD_NAMESPACE:MONSTER_ID", "..."]);
+	mod.api.customModifiersInMelvor.addMonsters("Human", ["MOD_NAMESPACE:MONSTER_ID", "MOD_NAMESPACE:MONSTER_ID", "..."]);
+	mod.api.customModifiersInMelvor.addMonsters("Dragon", ["MOD_NAMESPACE:MONSTER_ID", "MOD_NAMESPACE:MONSTER_ID", "..."]);
+	mod.api.customModifiersInMelvor.addMonsters("Undead", ["MOD_NAMESPACE:MONSTER_ID", "MOD_NAMESPACE:MONSTER_ID", "..."]);
 }
 ```

--- a/_definitions/Api.d.ts
+++ b/_definitions/Api.d.ts
@@ -53,10 +53,10 @@ declare namespace Modding {
              * @param typeNamePlural - the english plural variant of the type's name. Affects modifier name(s)
              * @param iconResourceUrl - a usable full URL to an image that will be used as icon for anything related to this type (e.g. "StackingEffects" or "Tiny Icon Mod Support")
              * @param monsterIds - a list of monster ids. If you are defining a type not covered by the base mod, you should include any Melvor monsters that may fit
-             * @param active - whether the type should be set to active - as a mod consuming the api, this is basically always going to be true, but can technically be set to false as well
+             * @param active - whether the type should be set to active (if omitted, will be set to "true") - as a mod consuming the api, this is basically always going to be true, but can technically be set to false as well
              * @returns
              */
-            registerOrUpdateType: (typeNameSingular: string, typeNamePlural: string, iconResourceUrl: string, monsterIds: string[], active: Boolean) => void
+            registerOrUpdateType: (typeNameSingular: string, typeNamePlural: string, iconResourceUrl: string, monsterIds: string[], active: Boolean = true) => void
 
             /**
              * Previously used with hard-definition of types, to retrieve info about which monsters are allocated as human

--- a/_definitions/Character.d.ts
+++ b/_definitions/Character.d.ts
@@ -1,9 +1,14 @@
 // IMPORTANT: Only types actually set to be active will be set like this, so true/truthy checks can only succeed in that case
 declare global {
     interface Character {
-        isHuman: boolean,
+        isAnimal: boolean,
+        isDemon: boolean,
         isDragon: boolean,
-        isUndead: boolean
+        isElemental: boolean,
+        isHuman: boolean,
+        isMythicalCreature: boolean,
+        isUndead: boolean,
+        isSeaCreature: boolean
     }
 }
 

--- a/_definitions/CombatModifierObject.d.ts
+++ b/_definitions/CombatModifierObject.d.ts
@@ -26,9 +26,13 @@ declare global {
         increasedDamageTakenFromFireSpells: Standard,
         decreasedDamageTakenFromFireSpells: Standard,
 
-        // Only for monster types set to be active
-        humanTraitApplied: Standard,
+        // Only for monster types defined by this base mod
+        animalTraitApplied: Standard,
+        demonTraitApplied: Standard,
         dragonTraitApplied: Standard,
+        elementalTraitApplied: Standard,
+        humanTraitApplied: Standard,
+        seaCreatureTraitApplied: Standard,
         undeadTraitApplied: Standard
     }
 }

--- a/_definitions/CombatModifiers.d.ts
+++ b/_definitions/CombatModifiers.d.ts
@@ -27,9 +27,13 @@ declare global {
         increasedDamageTakenFromFireSpells: number,
         decreasedDamageTakenFromFireSpells: number,
 
-        // Only for monster types set to be active
-        humanTraitApplied: number,
+        // Only for monster types defined by this base mod
+        animalTraitApplied: number,
+        demonTraitApplied: number,
         dragonTraitApplied: number,
+        elementalTraitApplied: number,
+        humanTraitApplied: number,
+        seaCreatureTraitApplied: number,
         undeadTraitApplied: number
     }
 }

--- a/_definitions/Game.d.ts
+++ b/_definitions/Game.d.ts
@@ -1,6 +1,22 @@
 declare global {
+    interface CmimStackingEffectCollection {
+        [key: string]: StackingEffect
+    }
+
+    interface CmimCustomModifierEffectCollection {
+        [key: string]: CustomEffectData
+    }
+
+    interface CmimSpecialAttackCollection {
+        [key: string]: SpecialAttack
+    }
+
     interface Game {
-        deathMarkEffect: StackingEffect
+        customModifiersInMelvor: {
+            stackingEffects: CmimStackingEffectCollection
+            customModifierEffects: CmimCustomModifierEffectCollection
+            specialAttacks: CmimSpecialAttackCollection
+        }
     }
 }
 

--- a/_definitions/MonsterType.d.ts
+++ b/_definitions/MonsterType.d.ts
@@ -1,5 +1,0 @@
-//declare global {
-//    declare type MonsterType = "Animal" | "Demon" | "Dragon" | "Elemental" | "Human" | "MythicalCreature" | "SeaCreature" | "Undead"
-//}
-
-//export { };

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -1,4 +1,5 @@
 export class Constants {
+    static readonly SCHEMA = "https://melvoridle.com/assets/schema/gameData.json";
     static readonly MOD_NAMESPACE = "customModifiersInMelvor";
 
     static readonly ERROR_ICON_MEDIA_PATH = "assets/media/main/error.svg";

--- a/src/GameObjectDataWrapperInitializer.ts
+++ b/src/GameObjectDataWrapperInitializer.ts
@@ -1,6 +1,6 @@
 /**
- * In order to have a clear overview of data added to the game-boject for quick-access,
- * said data is all wrapped up into an explaining object structure.
+ * In order to have a clear overview of data added to the game-object for quick-access,
+ * said data is all wrapped up into a self-explaining object structure.
  *
  * Said object structure has to be initialized though, which is done by this class.
  * It's therefore important, that this is among the first processes triggered during initialization of the mod

--- a/src/GameObjectDataWrapperInitializer.ts
+++ b/src/GameObjectDataWrapperInitializer.ts
@@ -1,0 +1,16 @@
+/**
+ * In order to have a clear overview of data added to the game-boject for quick-access,
+ * said data is all wrapped up into an explaining object structure.
+ *
+ * Said object structure has to be initialized though, which is done by this class.
+ * It's therefore important, that this is among the first processes triggered during initialization of the mod
+ */
+export class GameObjectDataWrapperInitializer {
+    public static process() {
+        game.customModifiersInMelvor = {
+            stackingEffects: {},
+            customModifierEffects: {},
+            specialAttacks: {}
+        };
+    }
+}

--- a/src/ModContextMemorizer.ts
+++ b/src/ModContextMemorizer.ts
@@ -1,14 +1,14 @@
 /**
- * After initial setup, the context object is memorized as a static variable,
+ * After initial setup, the context object is memoized as a static variable,
  * for easy access on things like api calls
  */
-export class ModContextMemorizer {
+export class ModContextMemoizer {
     private static _ctx: Modding.ModContext
     public static get ctx() {
-        return ModContextMemorizer._ctx;
+        return ModContextMemoizer._ctx;
     }
 
-    public static memorizeContext(ctx: Modding.ModContext) {
+    public static memoizeContext(ctx: Modding.ModContext) {
         this._ctx = ctx;
     }
 }

--- a/src/compatibility/TinyIconsCompatibility.ts
+++ b/src/compatibility/TinyIconsCompatibility.ts
@@ -191,6 +191,18 @@ export class TinyIconsCompatibility {
             modifiers[`${type.modifierPropertyNames.increasedDamageReduction}`] = [`${tagName}`, 'ti_dr_up'];
             // @ts-ignore
             modifiers[`${type.modifierPropertyNames.decreasedDamageReduction}`] = [`${tagName}`, 'ti_dr_dn'];
+            // @ts-ignore
+            modifiers[`${type.modifierPropertyNames.increasedChanceToApplyTraitInfiniteOnSpawn}`] = [`${tagName}`, 'combat'];
+            // @ts-ignore
+            modifiers[`${type.modifierPropertyNames.decreasedChanceToApplyTraitInfiniteOnSpawn}`] = [`${tagName}`, 'combat'];
+            // @ts-ignore
+            modifiers[`${type.modifierPropertyNames.applyTraitTurnsOnSpawn}`] = [`${tagName}`, 'combat'];
+            // @ts-ignore
+            modifiers[`${type.modifierPropertyNames.increasedChanceToApplyTrait}`] = [`${tagName}`, 'combat'];
+            // @ts-ignore
+            modifiers[`${type.modifierPropertyNames.decreasedChanceToApplyTrait}`] = [`${tagName}`, 'combat'];
+            // @ts-ignore
+            modifiers[`${type.modifierPropertyNames.applyTraitTurns}`] = [`${tagName}`, 'combat'];
 
             tinyIcons.addTagSources(cmimTagSources);
             tinyIcons.addCustomModifiers(modifiers);

--- a/src/components/MonsterTypeOverview.template.html
+++ b/src/components/MonsterTypeOverview.template.html
@@ -65,7 +65,13 @@
                         <!-- Player Trait Tab -->
                         <div id="monster-type-overview__player-traits-container"
                              class="col-12 d-none">
-                            <div class="mb-3 text-warning"><lang-string lang-id="customModifiersInMelvor_Monster_Type_Overview_Player_Traits_Information"></lang-string></div>
+                            <div class="mb-3 text-warning">
+                                <ul>
+                                    <li><lang-string lang-id="customModifiersInMelvor_Monster_Type_Overview_Player_Traits_Information_Type_Allocation"></lang-string></li>
+                                    <li><lang-string lang-id="customModifiersInMelvor_Monster_Type_Overview_Player_Traits_Information_Display"></lang-string></li>
+                                    <li><lang-string lang-id="customModifiersInMelvor_Monster_Type_Overview_Player_Traits_Information_Data_Loaded"></lang-string></li>
+                                </ul>
+                            </div>
                             <div v-if="props.traitsOnPlayer.length === 0"><lang-string lang-id="customModifiersInMelvor_Monster_Type_Overview_Player_Traits_No_Entries"></lang-string></div>
                             <ul v-if="props.traitsOnPlayer.length > 0">
                                 <li v-for="trait in props.traitsOnPlayer">{{ trait.name }} ({{ trait.value }})</li>

--- a/src/components/MonsterTypeOverview.ts
+++ b/src/components/MonsterTypeOverview.ts
@@ -50,8 +50,8 @@ export function MonsterTypeOverview(): Component<MonsterTypeOverviewProps> {
         });
 
         // Try to translate type name
-        const name = TranslationManager.getTranslationOrFallback(
-            `MONSTER_TYPE_PLURAL_${type.singularName}`,
+        const name = TranslationManager.getMonsterTypePluralNameTranslation(
+            type.singularName,
             type.pluralName
         );
 
@@ -68,8 +68,7 @@ export function MonsterTypeOverview(): Component<MonsterTypeOverviewProps> {
 
         // @ts-ignore
         if (game.combat.player.modifiers[type.modifierPropertyNames.traitApplied] > 0) {
-            const name = TranslationManager.getTranslationOrFallback(
-                `MONSTER_TYPE_SINGULAR_${type.singularName}`,
+            const name = TranslationManager.getMonsterTypeSingularNameTranslation(
                 type.singularName
             );
             // @ts-ignore

--- a/src/modifiers/Constants.ts
+++ b/src/modifiers/Constants.ts
@@ -5,13 +5,13 @@ export class Constants {
     static readonly DEATH_MARK_NOTIFICATION_ID = "DEATH_MARK_TRIGGERED";
     static readonly DEATH_MARK_NOTIFICATION_TEXT_LANGUAGE_ID = "customModifiersInMelvor:Death_Mark_Notification_Text";
 
-    static readonly TRAIT_STACKING_EFFECT_ID_SUFFIX = "Stacking_Trait_Effect";
+    // Names and descriptions are irrelevant, as those are defined through translation files
+    static readonly TRAIT_STACKING_EFFECT_ID_SUFFIX = "_Trait_Stacking_Effect";
     static readonly TRAIT_STACKING_EFFECT_NAME_SUFFIX = " Trait";
     static readonly TRAIT_STACKING_EFFECT_LANGUAGE_CATEGORY = "COMBAT_MISC";
-
-    //static readonly TRAIT_STACKING_EFFECT_ID_SUFFIX = "Stacking_Trait_Effect"; - not necessary
     static readonly TRAIT_CUSTOM_EFFECT_NAME_SUFFIX = " Trait";
     static readonly TRAIT_CUSTOM_EFFECT_LANGUAGE_CATEGORY = "COMBAT_MISC";
+    static readonly TRAIT_CUSTOM_EFFECT_ATTACK_ID_SUFFIX = "_Trait_Application_Attack";
 
     static readonly ANIMAL_MODIFIER_ICON_RESOURCE_URL = "https://cdn.melvor.net/core/v018/assets/media/monsters/frozen_mammoth.png";
     static readonly DEMON_MODIFIER_ICON_RESOURCE_URL = "https://cdn.melvor.net/core/v018/assets/media/monsters/fierce_devil.png";

--- a/src/modifiers/Constants.ts
+++ b/src/modifiers/Constants.ts
@@ -5,6 +5,14 @@ export class Constants {
     static readonly DEATH_MARK_NOTIFICATION_ID = "DEATH_MARK_TRIGGERED";
     static readonly DEATH_MARK_NOTIFICATION_TEXT_LANGUAGE_ID = "customModifiersInMelvor:Death_Mark_Notification_Text";
 
+    static readonly TRAIT_STACKING_EFFECT_ID_SUFFIX = "Stacking_Trait_Effect";
+    static readonly TRAIT_STACKING_EFFECT_NAME_SUFFIX = " Trait";
+    static readonly TRAIT_STACKING_EFFECT_LANGUAGE_CATEGORY = "COMBAT_MISC";
+
+    //static readonly TRAIT_STACKING_EFFECT_ID_SUFFIX = "Stacking_Trait_Effect"; - not necessary
+    static readonly TRAIT_CUSTOM_EFFECT_NAME_SUFFIX = " Trait";
+    static readonly TRAIT_CUSTOM_EFFECT_LANGUAGE_CATEGORY = "COMBAT_MISC";
+
     static readonly ANIMAL_MODIFIER_ICON_RESOURCE_URL = "https://cdn.melvor.net/core/v018/assets/media/monsters/frozen_mammoth.png";
     static readonly DEMON_MODIFIER_ICON_RESOURCE_URL = "https://cdn.melvor.net/core/v018/assets/media/monsters/fierce_devil.png";
     static readonly DRAGON_MODIFIER_ICON_RESOURCE_URL = "https://cdn.melvor.net/core/v018/assets/media/monsters/dragon_green.png";

--- a/src/modifiers/CustomModifiersManager.ts
+++ b/src/modifiers/CustomModifiersManager.ts
@@ -68,14 +68,11 @@ export class CustomModifiersManager {
             modifierData[value] = obj;
         });
 
-        // Create (non-stacking) custom effect data
+        // Create and register custom effect and stacking effect data
         const customEffectData: CustomEffectData = MonsterTypeHelper.createTraitCustomEffectDataInfiniteObject(type);
 
-        // @ts-ignore implicit 'any' type error
-        // we know though that it is an object to which we want to add a property
         game.customModifiersInMelvor.customModifierEffects[type.effectPropertyObjectNames.traitApplicationCustomModifierEffect] = customEffectData;
 
-        // Context game data is undefined, so we just go and call game.registerData directory
         game.registerDataPackage(MonsterTypeHelper.createTraitStackingEffectGamePackage(type));
         game.registerDataPackage(MonsterTypeHelper.createTraitCustomModifierEffectAttackGamePackage(type, customEffectData));
     }
@@ -994,8 +991,6 @@ export class CustomModifiersManager {
          * Register custom effects and attacks as properties on the Game object (akin to e.g. "unholyMarkEffect"), for easy and quick access
          */
         this.context.patch(Game, "postDataRegistration").after(function () {
-
-            // Then cache the effects and attacks on it
             const deathMarkEffect = this.stackingEffects.getObjectByID(ModifierConstants.DEATH_MARK_EFFECT_FULL_ID);
             if (deathMarkEffect) {
                 this.customModifiersInMelvor.stackingEffects.deathMarkEffect = deathMarkEffect;
@@ -1007,13 +1002,11 @@ export class CustomModifiersManager {
 
                 const stackingEffect = this.stackingEffects.getObjectByID(`${Constants.MOD_NAMESPACE}:${type.singularName}${ModifierConstants.TRAIT_STACKING_EFFECT_ID_SUFFIX}`);
                 if (stackingEffect) {
-                    // @ts-ignore: dynamic definition
                     this.customModifiersInMelvor.stackingEffects[type.effectPropertyObjectNames.traitApplicationStackingEffect] = stackingEffect;
                 }
 
                 const traitApplyingAttack = this.specialAttacks.getObjectByID(`${Constants.MOD_NAMESPACE}:${type.singularName}${ModifierConstants.TRAIT_CUSTOM_EFFECT_ATTACK_ID_SUFFIX}`);
                 if (traitApplyingAttack) {
-                    // @ts-ignore: dynamic definition
                     this.customModifiersInMelvor.specialAttacks[type.effectPropertyObjectNames.traitApplicationCustomModifierEffectAttack] = traitApplyingAttack;
                 }
             }
@@ -1114,13 +1107,10 @@ export class CustomModifiersManager {
                     - this.modifiers[type.modifierPropertyNames.decreasedChanceToApplyTraitInfiniteOnSpawn]
                 );
                 if (applyTraitInfinite) {
-                    // @ts-ignore: dynamic game property name
-                    const effect: ModifierEffect = game.customModifiersInMelvor.customModifierEffects[type.effectPropertyObjectNames.traitApplicationCustomModifierEffect];
-                    // @ts-ignore: dynamic game property name
-                    this.applyModifierEffect(effect, this.target, game.customModifiersInMelvor.specialAttacks[type.effectPropertyObjectNames.traitApplicationCustomModifierEffectAttack]);
+                    const effectData: CustomEffectData = game.customModifiersInMelvor.customModifierEffects[type.effectPropertyObjectNames.traitApplicationCustomModifierEffect];
+                    this.applyModifierEffect(effectData, this.target, game.customModifiersInMelvor.specialAttacks[type.effectPropertyObjectNames.traitApplicationCustomModifierEffectAttack]);
                 } else {
                     if (this.modifiers[type.modifierPropertyNames.applyTraitTurnsOnSpawn] > 0) {
-                        // @ts-ignore: dynamic game property name
                         this.applyStackingEffect(this.game.customModifiersInMelvor.stackingEffects[type.effectPropertyObjectNames.traitApplicationStackingEffect], this.target, this.modifiers[type.modifierPropertyNames.applyTraitTurnsOnSpawn]);
                     }
                 }
@@ -1206,7 +1196,6 @@ export class CustomModifiersManager {
                     }
 
                     if (turns > 0) {
-                        // @ts-ignore: dynamic game property name
                         this.applyStackingEffect(this.game.customModifiersInMelvor.stackingEffects[type.effectPropertyObjectNames.traitApplicationStackingEffect], this.target, turns);
                         this.target.rendersRequired.effects = true;
                     }

--- a/src/modifiers/CustomModifiersManager.ts
+++ b/src/modifiers/CustomModifiersManager.ts
@@ -73,7 +73,7 @@ export class CustomModifiersManager {
 
         // @ts-ignore implicit 'any' type error
         // we know though that it is an object to which we want to add a property
-        game[type.effectPropertyObjectNames.traitApplicationCustomModifierEffect] = customEffectData;
+        game.customModifiersInMelvor.customModifierEffects[type.effectPropertyObjectNames.traitApplicationCustomModifierEffect] = customEffectData;
 
         // Context game data is undefined, so we just go and call game.registerData directory
         game.registerDataPackage(MonsterTypeHelper.createTraitStackingEffectGamePackage(type));
@@ -994,9 +994,11 @@ export class CustomModifiersManager {
          * Register custom effects and attacks as properties on the Game object (akin to e.g. "unholyMarkEffect"), for easy and quick access
          */
         this.context.patch(Game, "postDataRegistration").after(function () {
+
+            // Then cache the effects and attacks on it
             const deathMarkEffect = this.stackingEffects.getObjectByID(ModifierConstants.DEATH_MARK_EFFECT_FULL_ID);
             if (deathMarkEffect) {
-                this.deathMarkEffect = deathMarkEffect;
+                this.customModifiersInMelvor.stackingEffects.deathMarkEffect = deathMarkEffect;
             }
 
             const types = MonsterTypeMappingManager.getActiveTypesAsArray();
@@ -1006,13 +1008,13 @@ export class CustomModifiersManager {
                 const stackingEffect = this.stackingEffects.getObjectByID(`${Constants.MOD_NAMESPACE}:${type.singularName}${ModifierConstants.TRAIT_STACKING_EFFECT_ID_SUFFIX}`);
                 if (stackingEffect) {
                     // @ts-ignore: dynamic definition
-                    this[type.effectPropertyObjectNames.traitApplicationStackingEffect] = stackingEffect;
+                    this.customModifiersInMelvor.stackingEffects[type.effectPropertyObjectNames.traitApplicationStackingEffect] = stackingEffect;
                 }
 
                 const traitApplyingAttack = this.specialAttacks.getObjectByID(`${Constants.MOD_NAMESPACE}:${type.singularName}${ModifierConstants.TRAIT_CUSTOM_EFFECT_ATTACK_ID_SUFFIX}`);
                 if (traitApplyingAttack) {
                     // @ts-ignore: dynamic definition
-                    this[type.effectPropertyObjectNames.traitApplicationCustomModifierEffectAttack] = traitApplyingAttack;
+                    this.customModifiersInMelvor.specialAttacks[type.effectPropertyObjectNames.traitApplicationCustomModifierEffectAttack] = traitApplyingAttack;
                 }
             }
         });
@@ -1113,13 +1115,13 @@ export class CustomModifiersManager {
                 );
                 if (applyTraitInfinite) {
                     // @ts-ignore: dynamic game property name
-                    const effect: ModifierEffect = game[type.effectPropertyObjectNames.traitApplicationCustomModifierEffect];
+                    const effect: ModifierEffect = game.customModifiersInMelvor.customModifierEffects[type.effectPropertyObjectNames.traitApplicationCustomModifierEffect];
                     // @ts-ignore: dynamic game property name
-                    this.applyModifierEffect(effect, this.target, game[type.effectPropertyObjectNames.traitApplicationCustomModifierEffectAttack]);
+                    this.applyModifierEffect(effect, this.target, game.customModifiersInMelvor.specialAttacks[type.effectPropertyObjectNames.traitApplicationCustomModifierEffectAttack]);
                 } else {
                     if (this.modifiers[type.modifierPropertyNames.applyTraitTurnsOnSpawn] > 0) {
                         // @ts-ignore: dynamic game property name
-                        this.applyStackingEffect(this.game[type.effectPropertyObjectNames.traitApplicationStackingEffect], this.target, this.modifiers[type.modifierPropertyNames.applyTraitTurnsOnSpawn]);
+                        this.applyStackingEffect(this.game.customModifiersInMelvor.stackingEffects[type.effectPropertyObjectNames.traitApplicationStackingEffect], this.target, this.modifiers[type.modifierPropertyNames.applyTraitTurnsOnSpawn]);
                     }
                 }
             }
@@ -1205,7 +1207,7 @@ export class CustomModifiersManager {
 
                     if (turns > 0) {
                         // @ts-ignore: dynamic game property name
-                        this.applyStackingEffect(this.game[type.effectPropertyObjectNames.traitApplicationStackingEffect], this.target, turns);
+                        this.applyStackingEffect(this.game.customModifiersInMelvor.stackingEffects[type.effectPropertyObjectNames.traitApplicationStackingEffect], this.target, turns);
                         this.target.rendersRequired.effects = true;
                     }
                 }

--- a/src/modifiers/CustomModifiersManager.ts
+++ b/src/modifiers/CustomModifiersManager.ts
@@ -13,7 +13,7 @@ export class CustomModifiersManager {
     constructor(private readonly context: Modding.ModContext) { }
 
     /**
-     * Registers all custom modifers, so they are known by the game
+     * Registers all non-dynamic custom modifers, so they are known by the game
      */
     public registerModifiers() {
         this.registerSkillModifiers();
@@ -56,6 +56,7 @@ export class CustomModifiersManager {
             return;
         }
 
+        // Create modifiers
         Object.entries(type.modifierPropertyNames).forEach(([key, value]) => {
             //console.log(`Processing modifierProperty: ${key} | ${value}`);
 
@@ -66,6 +67,9 @@ export class CustomModifiersManager {
             // we know though that it is an object to which we want to add a property
             modifierData[value] = obj;
         });
+
+        // Context game data is undefined, so we just go and call game.registerData directory
+        game.registerDataPackage(MonsterTypeHelper.createTraitStackingEffectGamePackage(type));
     }
 
     // #region Modifier Registration

--- a/src/modifiers/monsterTyping/MonsterTypeDefinition.ts
+++ b/src/modifiers/monsterTyping/MonsterTypeDefinition.ts
@@ -1,3 +1,4 @@
+import { MonsterTypeEffectObjectNames } from './MonsterTypeEffectObjectNames';
 import { MonsterTypeHelper } from './MonsterTypeHelper';
 import { MonsterTypeModifierPropertyNames } from './MonsterTypeModifierPropertyNames'
 
@@ -19,6 +20,8 @@ export class MonsterTypeDefinition {
     public isTypePropertyName: string
     public modifierPropertyNames: MonsterTypeModifierPropertyNames
 
+    public effectPropertyObjectNames: MonsterTypeEffectObjectNames
+
     /**
      * Create a new instance of a monster type definition
      * @param singularName - the main name for the type
@@ -34,6 +37,7 @@ export class MonsterTypeDefinition {
 
         this.isTypePropertyName = MonsterTypeHelper.createIsTypePropertyName(singularName);
         this.modifierPropertyNames = MonsterTypeHelper.createModifierPropertyNames(singularName, pluralName);
+        this.effectPropertyObjectNames = MonsterTypeHelper.createEffectPropertyNames(singularName);
     }
 
     /**

--- a/src/modifiers/monsterTyping/MonsterTypeEffectObjectNames.ts
+++ b/src/modifiers/monsterTyping/MonsterTypeEffectObjectNames.ts
@@ -1,5 +1,5 @@
 /**
- * Defines the ultimately dynamically built names for effects,
+ * Defines the ultimately dynamically built names for effects and attacks,
  * which are pre-build and quickly accessible through the 'Game' object
  */
 export interface MonsterTypeEffectObjectNames {

--- a/src/modifiers/monsterTyping/MonsterTypeEffectObjectNames.ts
+++ b/src/modifiers/monsterTyping/MonsterTypeEffectObjectNames.ts
@@ -1,0 +1,9 @@
+/**
+ * Defines the ultimately dynamically built names for effects,
+ * which are pre-build and quickly accessible through the 'Game' object
+ */
+export interface MonsterTypeEffectObjectNames {
+    traitApplicationStackingEffect: string
+    traitApplicationCustomModifierEffect: string
+    traitApplicationCustomModifierEffectAttack: string
+}

--- a/src/modifiers/monsterTyping/MonsterTypeHelper.ts
+++ b/src/modifiers/monsterTyping/MonsterTypeHelper.ts
@@ -1,8 +1,11 @@
+import { Constants } from '../../Constants';
+import { Constants as ModifierConstants } from '../Constants';
 import { MonsterTypeDefinition } from './MonsterTypeDefinition';
 import { MonsterTypeMappingManager } from './MonsterTypeMappingManager';
 import { MonsterTypeModifierGroup } from './MonsterTypeModifierGroup';
 import { MonsterTypeModifierPropertyNames } from './MonsterTypeModifierPropertyNames'
 import { MonsterTypeModifierType } from './MonsterTypeModifierType'
+import { TranslationManager } from '../../translation/TranslationManager';
 
 export class MonsterTypeHelper {
     /**
@@ -90,6 +93,48 @@ export class MonsterTypeHelper {
         }
 
         return modifierObject;
+    }
+
+    /**
+     *
+     * @param type
+     * @returns
+     */
+    public static createTraitStackingEffectGamePackage(type: MonsterTypeDefinition): GameDataPackage {
+        return {
+            "$schema": Constants.SCHEMA,
+            "namespace": Constants.MOD_NAMESPACE,
+            "data": {
+                "stackingEffects": [MonsterTypeHelper.createTraitStackingEffectDataObject(type)]
+            }
+        }
+    }
+
+    /**
+     *
+     * @param type
+     * @returns
+     */
+    private static createTraitStackingEffectDataObject(type: MonsterTypeDefinition): StackingEffectData {
+        var obj: StackingEffectData = {
+            id: `${type.singularName}${ModifierConstants.TRAIT_STACKING_EFFECT_ID_SUFFIX}`,
+            stacksToAdd: 1,
+            maxStacks: 99,
+            name: `${type.singularName}${ModifierConstants.TRAIT_STACKING_EFFECT_NAME_SUFFIX}`,
+            langName: {
+                category: ModifierConstants.TRAIT_STACKING_EFFECT_LANGUAGE_CATEGORY,
+                id: `${type.singularName}${ModifierConstants.TRAIT_STACKING_EFFECT_ID_SUFFIX}`
+            },
+            media: type.iconResourceUrl,
+            modifiers: {
+
+            }
+        };
+
+        // @ts-ignore Ignore implicit any error
+        obj.modifiers[type.modifierPropertyNames.traitApplied] = 1;
+
+        return obj;
     }
 
     /**

--- a/src/modifiers/monsterTyping/MonsterTypeHelper.ts
+++ b/src/modifiers/monsterTyping/MonsterTypeHelper.ts
@@ -1,11 +1,11 @@
 import { Constants } from '../../Constants';
 import { Constants as ModifierConstants } from '../Constants';
 import { MonsterTypeDefinition } from './MonsterTypeDefinition';
+import { MonsterTypeEffectObjectNames } from './MonsterTypeEffectObjectNames';
 import { MonsterTypeMappingManager } from './MonsterTypeMappingManager';
 import { MonsterTypeModifierGroup } from './MonsterTypeModifierGroup';
 import { MonsterTypeModifierPropertyNames } from './MonsterTypeModifierPropertyNames'
 import { MonsterTypeModifierType } from './MonsterTypeModifierType'
-import { TranslationManager } from '../../translation/TranslationManager';
 
 export class MonsterTypeHelper {
     /**
@@ -25,9 +25,9 @@ export class MonsterTypeHelper {
      * @returns
      */
     public static createModifierPropertyNames(typeSingularName: string, typePluralName: string): MonsterTypeModifierPropertyNames {
-        typeSingularName = `${typeSingularName[0].toLowerCase()}${typeSingularName.substring(1)}`;
+        const typeSingularNameLower = `${typeSingularName[0].toLowerCase()}${typeSingularName.substring(1)}`;
         return {
-            traitApplied: `${typeSingularName}TraitApplied`,
+            traitApplied: `${typeSingularNameLower}TraitApplied`,
             increasedDamage: `increasedDamageAgainst${typePluralName}`,
             decreasedDamage: `decreasedDamageAgainst${typePluralName}`,
             increasedDamageTaken: `increasedDamageTakenFrom${typePluralName}`,
@@ -44,6 +44,24 @@ export class MonsterTypeHelper {
             decreasedGlobalAccuracy: `decreasedGlobalAccuracyAgainst${typePluralName}`,
             increasedDamageReduction: `increasedDamageReductionAgainst${typePluralName}`,
             decreasedDamageReduction: `decreasedDamageReductionAgainst${typePluralName}`,
+
+
+            increasedChanceToApplyTraitInfiniteOnSpawn: `increasedChanceToApply${typeSingularName}TraitInfiniteOnSpawn`,
+            decreasedChanceToApplyTraitInfiniteOnSpawn: `decreasedChanceToApply${typeSingularName}TraitInfiniteOnSpawn`,
+            applyTraitTurnsOnSpawn: `apply${typeSingularName}TraitTurnsOnSpawn`,
+
+            increasedChanceToApplyTrait: `increasedChanceToApply${typeSingularName}Trait`,
+            decreasedChanceToApplyTrait: `decreasedChanceToApply${typeSingularName}Trait`,
+            applyTraitTurns: `apply${typeSingularName}TraitTurns`
+        };
+    }
+
+    public static createEffectPropertyNames(typeSingularName: string): MonsterTypeEffectObjectNames {
+        const typeSingularNameLower = `${typeSingularName[0].toLowerCase()}${typeSingularName.substring(1)}`;
+        return {
+            traitApplicationCustomModifierEffect: `${typeSingularNameLower}TraitApplicationCustomEffect`,
+            traitApplicationStackingEffect: `${typeSingularNameLower}TraitApplicationStackingEffect`,
+            traitApplicationCustomModifierEffectAttack: `${typeSingularNameLower}TraitApplyingAttack`
         };
     }
 
@@ -75,6 +93,8 @@ export class MonsterTypeHelper {
             case MonsterTypeModifierType.DecreasedFlatMinHit:
             case MonsterTypeModifierType.DecreasedGlobalAccuracy:
             case MonsterTypeModifierType.DecreasedDamageReduction:
+            case MonsterTypeModifierType.DecreasedChanceToApplyTraitInfiniteOnSpawn:
+            case MonsterTypeModifierType.DecreasedChanceToApplyTrait:
                 modifierObject.isNegative = true;
                 break;
             default:
@@ -116,7 +136,7 @@ export class MonsterTypeHelper {
      * @returns
      */
     private static createTraitStackingEffectDataObject(type: MonsterTypeDefinition): StackingEffectData {
-        var obj: StackingEffectData = {
+        let obj: StackingEffectData = {
             id: `${type.singularName}${ModifierConstants.TRAIT_STACKING_EFFECT_ID_SUFFIX}`,
             stacksToAdd: 1,
             maxStacks: 99,
@@ -126,6 +146,78 @@ export class MonsterTypeHelper {
                 id: `${type.singularName}${ModifierConstants.TRAIT_STACKING_EFFECT_ID_SUFFIX}`
             },
             media: type.iconResourceUrl,
+            modifiers: {
+
+            }
+        };
+
+        // @ts-ignore Ignore implicit any error
+        obj.modifiers[type.modifierPropertyNames.traitApplied] = 1;
+
+        return obj;
+    }
+
+    /**
+     * Custom effects that aren't specifically defined to be an exception to the rule (see "saveWriter.writeEffect"),
+     * must be identifiable through an Id, in order to be serializable to game character save file.
+     *
+     * This method takes care of creating a registerable package for said effect
+     * @param type
+     * @returns
+     */
+    public static createTraitCustomModifierEffectAttackGamePackage(type: MonsterTypeDefinition, customEffectData: CustomEffectData): GameDataPackage {
+        return {
+            "$schema": Constants.SCHEMA,
+            "namespace": Constants.MOD_NAMESPACE,
+            "data": {
+                "attacks": [MonsterTypeHelper.createTraitCustomEffectAttackDataObject(type, customEffectData)]
+            }
+        }
+    }
+
+    /**
+     *
+     * @param type
+     * @returns
+     */
+    private static createTraitCustomEffectAttackDataObject(type: MonsterTypeDefinition, customEffectData: CustomEffectData): AttackData {
+        let attack: AttackData = {
+            id: `${type.singularName}${ModifierConstants.TRAIT_CUSTOM_EFFECT_ATTACK_ID_SUFFIX}`,
+            defaultChance: 0, // only used for manual triggering, so irrelevant
+            damage: [{
+                damageType: "Normal",
+                amplitude: 0
+            }], // we only define a preHitEffect, this shouldn't deal any damage
+            prehitEffects: [customEffectData],
+            onhitEffects: [],
+            cantMiss: false,
+            attackCount: 1,
+            attackInterval: -1,
+            lifesteal: 0,
+            name: "Trait application",
+            description: "Performs a non-damaging, pre-hit-effect-only attack that applies the given trait"
+        }
+
+        return attack;
+    }
+
+    /**
+     *
+     * @param type
+     * @returns
+     */
+    public static createTraitCustomEffectDataInfiniteObject(type: MonsterTypeDefinition): CustomEffectData {
+        const obj: CustomEffectData = {
+            effectType: "Custom",
+            type: 'Modifier',
+            maxStacks: 1,
+            stacksToAdd: 1,
+            turns: Infinity,
+            character: "Target",
+            countsOn: "Target",
+            media: type.iconResourceUrl,
+            name: `${type.singularName}${ModifierConstants.TRAIT_CUSTOM_EFFECT_NAME_SUFFIX}`,
+            langName: `${ModifierConstants.TRAIT_CUSTOM_EFFECT_LANGUAGE_CATEGORY}_${type.singularName}_Trait_Modifier_Effect`,
             modifiers: {
 
             }
@@ -265,6 +357,10 @@ export class MonsterTypeHelper {
 
     /**
      * Calculates modification for cases that are "valid", if ONESELF is treated as the corresponding type
+     *
+     * NOTE: The naming can be a little hard to discern, but "damage taken" runs during the same calculation as "damage".
+     * There, whether is has an effect is actually based on what modifiers the ENEMY has, not oneself.
+     * Inadvertenly, who has to have their type checked is also flipped on its head
      * @param entity
      * @param modifierGroup
      * @param type

--- a/src/modifiers/monsterTyping/MonsterTypeHelper.ts
+++ b/src/modifiers/monsterTyping/MonsterTypeHelper.ts
@@ -44,12 +44,9 @@ export class MonsterTypeHelper {
             decreasedGlobalAccuracy: `decreasedGlobalAccuracyAgainst${typePluralName}`,
             increasedDamageReduction: `increasedDamageReductionAgainst${typePluralName}`,
             decreasedDamageReduction: `decreasedDamageReductionAgainst${typePluralName}`,
-
-
             increasedChanceToApplyTraitInfiniteOnSpawn: `increasedChanceToApply${typeSingularName}TraitInfiniteOnSpawn`,
             decreasedChanceToApplyTraitInfiniteOnSpawn: `decreasedChanceToApply${typeSingularName}TraitInfiniteOnSpawn`,
             applyTraitTurnsOnSpawn: `apply${typeSingularName}TraitTurnsOnSpawn`,
-
             increasedChanceToApplyTrait: `increasedChanceToApply${typeSingularName}Trait`,
             decreasedChanceToApplyTrait: `decreasedChanceToApply${typeSingularName}Trait`,
             applyTraitTurns: `apply${typeSingularName}TraitTurns`

--- a/src/modifiers/monsterTyping/MonsterTypeMappingManager.ts
+++ b/src/modifiers/monsterTyping/MonsterTypeMappingManager.ts
@@ -1,7 +1,7 @@
 import { Constants } from '../../Constants';
 import { Constants as ModifierConstants } from '../Constants'
 import { CustomModifiersManager } from '../CustomModifiersManager';
-import { ModContextMemorizer } from '../../ModContextMemorizer';
+import { ModContextMemoizer } from '../../ModContextMemorizer';
 import { MonsterType } from './MonsterType'
 import { MonsterTypeDefinition } from './MonsterTypeDefinition';
 import { TinyIconsCompatibility } from '../../compatibility/TinyIconsCompatibility';
@@ -248,13 +248,13 @@ export class MonsterTypeMappingManager {
      * @param type
      */
     public static registerData(type: MonsterTypeDefinition) {
-        const modifierManager = new CustomModifiersManager(ModContextMemorizer.ctx);
+        const modifierManager = new CustomModifiersManager(ModContextMemoizer.ctx);
         modifierManager.registerMonsterType(type);
 
-        const translationManager = new TranslationManager(ModContextMemorizer.ctx);
+        const translationManager = new TranslationManager(ModContextMemoizer.ctx);
         translationManager.registerMonsterType(type);
 
-        const tinyIconCompatibility = new TinyIconsCompatibility(ModContextMemorizer.ctx);
+        const tinyIconCompatibility = new TinyIconsCompatibility(ModContextMemoizer.ctx);
         tinyIconCompatibility.registerMonsterType(type);
     }
 

--- a/src/modifiers/monsterTyping/MonsterTypeModifierPropertyNames.ts
+++ b/src/modifiers/monsterTyping/MonsterTypeModifierPropertyNames.ts
@@ -20,4 +20,10 @@ export interface MonsterTypeModifierPropertyNames {
     decreasedGlobalAccuracy: string,
     increasedDamageReduction: string,
     decreasedDamageReduction: string,
+    increasedChanceToApplyTraitInfiniteOnSpawn: string,
+    decreasedChanceToApplyTraitInfiniteOnSpawn: string,
+    applyTraitTurnsOnSpawn: string,
+    increasedChanceToApplyTrait: string,
+    decreasedChanceToApplyTrait: string,
+    applyTraitTurns: string
 }

--- a/src/modifiers/monsterTyping/MonsterTypeModifierType.ts
+++ b/src/modifiers/monsterTyping/MonsterTypeModifierType.ts
@@ -16,4 +16,10 @@ export enum MonsterTypeModifierType {
     DecreasedGlobalAccuracy = "decreasedGlobalAccuracy",
     IncreasedDamageReduction = "increasedDamageReduction",
     DecreasedDamageReduction = "decreasedDamageReduction",
+    IncreasedChanceToApplyTraitInfiniteOnSpawn = "increasedChanceToApplyTraitInfiniteOnSpawn",
+    DecreasedChanceToApplyTraitInfiniteOnSpawn = "decreasedChanceToApplyTraitInfiniteOnSpawn",
+    ApplyTraitTurnsOnSpawn = "applyTraitTurnsOnSpawn",
+    IncreasedChanceToApplyTrait = "increasedChanceToApplyTrait",
+    DecreasedChanceToApplyTrait = "decreasedChanceToApplyTrait",
+    ApplyTraitTurns = "applyTraitTurns"
 }

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -50,7 +50,7 @@ function initApiEndpoints(ctx: Modding.ModContext) {
         getActiveTypes: () => MonsterTypeMappingManager.getActiveTypes(),
         getInactiveTypes: () => MonsterTypeMappingManager.getInactiveTypes(),
         monsterIsOfType: (monster: Monster, monsterType: string | MonsterType) => MonsterTypeMappingManager.monsterIsOfType(monster, monsterType),
-        registerOrUpdateType: (typeNameSingular: string, typeNamePlural: string, iconResourceUrl: string, monsterIds: string[], active: Boolean) => MonsterTypeMappingManager.registerOrUpdateType(typeNameSingular, typeNamePlural, iconResourceUrl, monsterIds, active),
+        registerOrUpdateType: (typeNameSingular: string, typeNamePlural: string, iconResourceUrl: string, monsterIds: string[], active: Boolean = true) => MonsterTypeMappingManager.registerOrUpdateType(typeNameSingular, typeNamePlural, iconResourceUrl, monsterIds, active),
 
         // DEPRACATED
         getHumans: () => MonsterTypeMappingManager.getHumans(),

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -1,7 +1,7 @@
 // Modules
 // You can import script modules and have full type completion
 import { CustomModifiersManager } from './modifiers/CustomModifiersManager';
-import { ModContextMemorizer } from './ModContextMemorizer';
+import { ModContextMemoizer } from './ModContextMemorizer';
 import { MonsterType } from './modifiers/monsterTyping/MonsterType';
 import { MonsterTypeMappingManager } from './modifiers/monsterTyping/MonsterTypeMappingManager';
 import { MonsterTypeOverview } from './components/MonsterTypeOverview'
@@ -37,7 +37,7 @@ export async function setup(ctx: Modding.ModContext) {
     //await ctx.gameData.addPackage(ModTestData);
 
     // Memorize context, to make it easily accessable on mod api calls by other mods
-    ModContextMemorizer.memorizeContext(ctx);
+    ModContextMemoizer.memoizeContext(ctx);
 }
 
 /**

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -18,11 +18,13 @@ import ModData from '../data/data.json'
 import '../assets/Logo.png'
 import '../assets/Death_Mark.png'
 import '../assets/Invoke_Death.png'
+import { GameObjectDataWrapperInitializer } from './GameObjectDataWrapperInitializer';
 // #endregion
 
 export async function setup(ctx: Modding.ModContext) {
     // Register custom modifier logic patches and localized texts
     initApiEndpoints(ctx);
+    initGameObjectDataWrapper();
     initCustomModifiers(ctx);
     initTranslation(ctx);
     initOverviewContainer(ctx);
@@ -63,6 +65,13 @@ function initApiEndpoints(ctx: Modding.ModContext) {
         monsterIsDragon: (monster: Monster) => MonsterTypeMappingManager.monsterIsOfType(monster, MonsterType.Dragon),
         monsterIsUndead: (monster: Monster) => MonsterTypeMappingManager.monsterIsOfType(monster, MonsterType.Undead)
     });
+}
+
+/**
+ * As one of the first steps, initialize object structure for game-object-quick-access-data
+ */
+function initGameObjectDataWrapper() {
+    GameObjectDataWrapperInitializer.process();
 }
 
 /**

--- a/src/translation/TranslationManager.ts
+++ b/src/translation/TranslationManager.ts
@@ -68,7 +68,8 @@ export class TranslationManager {
 
         const typePluralName = TranslationManager.getMonsterTypePluralNameTranslation(type.singularName, type.pluralName);
         //console.log(`translationManager | registerMonsterType | key: MONSTER_TYPE_PLURAL_${type.singularName} | value: ${typePluralName}`);
-        loadedLangJson[`COMBAT_MISC_${type.singularName}_Trait_Effect`] = loadedLangJson["COMBAT_MISC_Monster_Type_Trait_Effect"].replace("${monsterType}", typeSingularName);
+        loadedLangJson[`COMBAT_MISC_${type.singularName}_Trait_Modifier_Effect`] = loadedLangJson["COMBAT_MISC_Monster_Type_Trait_Modifier_Effect"].replace("${monsterType}", typeSingularName);
+        loadedLangJson[`COMBAT_MISC_${type.singularName}_Trait_Stacking_Effect`] = loadedLangJson["COMBAT_MISC_Monster_Type_Trait_Stacking_Effect"].replace("${monsterType}", typeSingularName);
 
         loadedLangJson[`MODIFIER_DATA_${type.modifierPropertyNames.traitApplied}`] = loadedLangJson["MODIFIER_DATA_MonsterTypeTraitApplied"].replace("${monsterType}", typeSingularName);
         loadedLangJson[`MODIFIER_DATA_${type.modifierPropertyNames.increasedDamage}`] = loadedLangJson["MODIFIER_DATA_increasedDamageAgainstMonsterType"].replace("${monsterType}", typePluralName);
@@ -87,6 +88,14 @@ export class TranslationManager {
         loadedLangJson[`MODIFIER_DATA_${type.modifierPropertyNames.decreasedGlobalAccuracy}`] = loadedLangJson["MODIFIER_DATA_decreasedGlobalAccuracyAgainstMonsterType"].replace("${monsterType}", typePluralName);
         loadedLangJson[`MODIFIER_DATA_${type.modifierPropertyNames.increasedDamageReduction}`] = loadedLangJson["MODIFIER_DATA_increasedDamageReductionAgainstMonsterType"].replace("${monsterType}", typePluralName);
         loadedLangJson[`MODIFIER_DATA_${type.modifierPropertyNames.decreasedDamageReduction}`] = loadedLangJson["MODIFIER_DATA_decreasedDamageReductionAgainstMonsterType"].replace("${monsterType}", typePluralName);
+
+        loadedLangJson[`MODIFIER_DATA_${type.modifierPropertyNames.increasedChanceToApplyTraitInfiniteOnSpawn}`] = loadedLangJson["MODIFIER_DATA_increasedChanceToApplyMonsterTypeTraitInfiniteOnSpawn"].replace("${monsterType}", typeSingularName);
+        loadedLangJson[`MODIFIER_DATA_${type.modifierPropertyNames.decreasedChanceToApplyTraitInfiniteOnSpawn}`] = loadedLangJson["MODIFIER_DATA_decreasedChanceToApplyMonsterTypeTraitInfiniteOnSpawn"].replace("${monsterType}", typeSingularName);
+        loadedLangJson[`MODIFIER_DATA_${type.modifierPropertyNames.applyTraitTurnsOnSpawn}`] = loadedLangJson["MODIFIER_DATA_applyMonserTypeTraitTurnsOnSpawn"].replace("${monsterType}", typeSingularName);
+
+        loadedLangJson[`MODIFIER_DATA_${type.modifierPropertyNames.increasedChanceToApplyTrait}`] = loadedLangJson["MODIFIER_DATA_increasedChanceToApplyMonsterTypeTrait"].replace("${monsterType}", typeSingularName);
+        loadedLangJson[`MODIFIER_DATA_${type.modifierPropertyNames.decreasedChanceToApplyTrait}`] = loadedLangJson["MODIFIER_DATA_decreasedChanceToApplyMonsterTypeTrait"].replace("${monsterType}", typeSingularName);
+        loadedLangJson[`MODIFIER_DATA_${type.modifierPropertyNames.applyTraitTurns}`] = loadedLangJson["MODIFIER_DATA_applyMonsterTypeTraitTurns"].replace("${monsterType}", typeSingularName);
     }
 
     /**

--- a/src/translation/TranslationManager.ts
+++ b/src/translation/TranslationManager.ts
@@ -63,11 +63,12 @@ export class TranslationManager {
      * @param type
      */
     public registerMonsterType(type: MonsterTypeDefinition): void {
-        const typeSingularName = TranslationManager.getTranslationOrFallback(`MONSTER_TYPE_SINGULAR_${type.singularName}`, type.singularName);
+        const typeSingularName = TranslationManager.getMonsterTypeSingularNameTranslation(type.singularName);
         //console.log(`translationManager | registerMonsterType | key: MONSTER_TYPE_SINGULAR_${type.singularName} | value: ${typeSingularName}`);
 
-        const typePluralName = TranslationManager.getTranslationOrFallback(`MONSTER_TYPE_PLURAL_${type.singularName}`, type.pluralName);
+        const typePluralName = TranslationManager.getMonsterTypePluralNameTranslation(type.singularName, type.pluralName);
         //console.log(`translationManager | registerMonsterType | key: MONSTER_TYPE_PLURAL_${type.singularName} | value: ${typePluralName}`);
+        loadedLangJson[`COMBAT_MISC_${type.singularName}_Trait_Effect`] = loadedLangJson["COMBAT_MISC_Monster_Type_Trait_Effect"].replace("${monsterType}", typeSingularName);
 
         loadedLangJson[`MODIFIER_DATA_${type.modifierPropertyNames.traitApplied}`] = loadedLangJson["MODIFIER_DATA_MonsterTypeTraitApplied"].replace("${monsterType}", typeSingularName);
         loadedLangJson[`MODIFIER_DATA_${type.modifierPropertyNames.increasedDamage}`] = loadedLangJson["MODIFIER_DATA_increasedDamageAgainstMonsterType"].replace("${monsterType}", typePluralName);
@@ -86,6 +87,25 @@ export class TranslationManager {
         loadedLangJson[`MODIFIER_DATA_${type.modifierPropertyNames.decreasedGlobalAccuracy}`] = loadedLangJson["MODIFIER_DATA_decreasedGlobalAccuracyAgainstMonsterType"].replace("${monsterType}", typePluralName);
         loadedLangJson[`MODIFIER_DATA_${type.modifierPropertyNames.increasedDamageReduction}`] = loadedLangJson["MODIFIER_DATA_increasedDamageReductionAgainstMonsterType"].replace("${monsterType}", typePluralName);
         loadedLangJson[`MODIFIER_DATA_${type.modifierPropertyNames.decreasedDamageReduction}`] = loadedLangJson["MODIFIER_DATA_decreasedDamageReductionAgainstMonsterType"].replace("${monsterType}", typePluralName);
+    }
+
+    /**
+     *
+     * @param typeNameSingular
+     * @returns
+     */
+    public static getMonsterTypeSingularNameTranslation(typeNameSingular: string): string {
+        return TranslationManager.getTranslationOrFallback(`MONSTER_TYPE_SINGULAR_${typeNameSingular}`, typeNameSingular);
+    }
+
+    /**
+     *
+     * @param typeNameSingular
+     * @param typeNamePlural
+     * @returns
+     */
+    public static getMonsterTypePluralNameTranslation(typeNameSingular: string, typeNamePlural: string): string {
+        return TranslationManager.getTranslationOrFallback(`MONSTER_TYPE_PLURAL_${typeNameSingular}`, typeNamePlural);
     }
 
     /**

--- a/src/translation/languages/chinese-simplified.ts
+++ b/src/translation/languages/chinese-simplified.ts
@@ -9,7 +9,7 @@ export const zhCN = {
 
     Monster_Type_Overview_Player_Traits_Tab_Header: "Player traits",
     Monster_Type_Overview_Player_Traits_Information_Type_Allocation: "Aside from organic type allocation, a type can also be forcefully applied by usage of the respective modifier, usually through equipped items or possibly shop purchase(s)",
-    Monster_Type_Overview_Player_Traits_Information_Display: "This overview displays all types (and their modifier's value) currently affecting the Character - more info may be determinable using the "Show Skill Modifiers" mod",
+    Monster_Type_Overview_Player_Traits_Information_Display: 'This overview displays all types (and the value of the modifier) currently affecting the Character - more info may be determinable using the "Show Skill Modifiers" mod',
     Monster_Type_Overview_Player_Traits_Information_Data_Loaded: "This display is static, based on when the character was loaded",
     Monster_Type_Overview_Player_Traits_No_Entries: "The character is not affected by any type allocation modifiers",
 
@@ -122,6 +122,8 @@ export const zhCN = {
     MONSTER_TYPE_PLURAL_SeaCreature: "Sea Creatures",
     MONSTER_TYPE_SINGULAR_Undead: "Undead",
     MONSTER_TYPE_PLURAL_Undead: "Undead",
+
+    COMBAT_MISC_Monster_Type_Trait_Effect: "${monsterType} Trait",
 
     MODIFIER_DATA_MonsterTypeTraitApplied: "Marks the affected as ${monsterType}",
     MODIFIER_DATA_increasedDamageAgainstMonsterType: "+${value}% Damage To ${monsterType}",

--- a/src/translation/languages/chinese-simplified.ts
+++ b/src/translation/languages/chinese-simplified.ts
@@ -8,7 +8,9 @@ export const zhCN = {
     Monster_Type_Overview_Remarks_Custom_Mods_Monster_Type_Allocation: "For any monsters added through other mods, said mods have to set type definitions themselves for those monsters",
 
     Monster_Type_Overview_Player_Traits_Tab_Header: "Player traits",
-    Monster_Type_Overview_Player_Traits_Information: "Aside from organic type allocation, a type can also be forcefully applied by usage of the respective modifier, usually through equipped items or possibly shop purchase(s). This overview displays all types (and their modifier's value) currently affecting the Character. THIS DISPLAY IS STATIC, BASED ON WHEN THE CHARACTER WAS LOADED!",
+    Monster_Type_Overview_Player_Traits_Information_Type_Allocation: "Aside from organic type allocation, a type can also be forcefully applied by usage of the respective modifier, usually through equipped items or possibly shop purchase(s)",
+    Monster_Type_Overview_Player_Traits_Information_Display: "This overview displays all types (and their modifier's value) currently affecting the Character - more info may be determinable using the "Show Skill Modifiers" mod",
+    Monster_Type_Overview_Player_Traits_Information_Data_Loaded: "This display is static, based on when the character was loaded",
     Monster_Type_Overview_Player_Traits_No_Entries: "The character is not affected by any type allocation modifiers",
 
     Monster_Type_Overview_Active_Types_Tab_Header: "Active types",

--- a/src/translation/languages/chinese-simplified.ts
+++ b/src/translation/languages/chinese-simplified.ts
@@ -124,6 +124,7 @@ export const zhCN = {
     MONSTER_TYPE_PLURAL_Undead: "Undead",
 
     COMBAT_MISC_Monster_Type_Trait_Effect: "${monsterType} Trait",
+    COMBAT_MISC_Monster_Type_Trait_Stacking_Effect: "${monsterType} Trait",
 
     MODIFIER_DATA_MonsterTypeTraitApplied: "Marks the affected as ${monsterType}",
     MODIFIER_DATA_increasedDamageAgainstMonsterType: "+${value}% Damage To ${monsterType}",
@@ -142,6 +143,14 @@ export const zhCN = {
     MODIFIER_DATA_decreasedGlobalAccuracyAgainstMonsterType: '-${value}% Accuracy Rating when fighting ${monsterType}',
     MODIFIER_DATA_increasedDamageReductionAgainstMonsterType: '+${value}% Damage Reduction when fighting ${monsterType}',
     MODIFIER_DATA_decreasedDamageReductionAgainstMonsterType: '-${value}% Damage Reduction when fighting ${monsterType}',
+
+    MODIFIER_DATA_increasedChanceToApplyMonsterTypeTraitInfiniteOnSpawn: '+${value}% chance to apply ${monsterType} trait for the whole fight on spawn or revive',
+    MODIFIER_DATA_decreasedChanceToApplyMonsterTypeTraitInfiniteOnSpawn: '-${value}% chance to apply ${monsterType} trait for the whole fight on spawn or revive',
+    MODIFIER_DATA_applyMonserTypeTraitTurnsOnSpawn: "Apply ${monsterType} trait on enemy for ${value} of the enemies' turns on spawn or revive",
+
+    MODIFIER_DATA_increasedChanceToApplyMonsterTypeTrait: "+${value}% chance to apply ${monsterType} trait for one of the enemies' turns",
+    MODIFIER_DATA_decreasedChanceToApplyMonsterTypeTrait: "-${value}% chance to apply ${monsterType} trait for one of the enemies' turns",
+    MODIFIER_DATA_applyMonsterTypeTraitTurns: "Apply ${monsterType} trait on enemy for ${value} of the enemies' turns",
 
     // #### Bosses
     MODIFIER_DATA_increasedMaxHitPercentAgainstBosses: "+${value}% Max Hit when fighting bosses",

--- a/src/translation/languages/chinese-simplified.ts
+++ b/src/translation/languages/chinese-simplified.ts
@@ -123,7 +123,7 @@ export const zhCN = {
     MONSTER_TYPE_SINGULAR_Undead: "Undead",
     MONSTER_TYPE_PLURAL_Undead: "Undead",
 
-    COMBAT_MISC_Monster_Type_Trait_Effect: "${monsterType} Trait",
+    COMBAT_MISC_Monster_Type_Trait_Modifier_Effect: "${monsterType} Trait",
     COMBAT_MISC_Monster_Type_Trait_Stacking_Effect: "${monsterType} Trait",
 
     MODIFIER_DATA_MonsterTypeTraitApplied: "Marks the affected as ${monsterType}",

--- a/src/translation/languages/chinese-traditional.ts
+++ b/src/translation/languages/chinese-traditional.ts
@@ -123,7 +123,7 @@ export const zhTW = {
     MONSTER_TYPE_SINGULAR_Undead: "Undead",
     MONSTER_TYPE_PLURAL_Undead: "Undead",
 
-    COMBAT_MISC_Monster_Type_Trait_Effect: "${monsterType} Trait",
+    COMBAT_MISC_Monster_Type_Trait_Modifier_Effect: "${monsterType} Trait",
     COMBAT_MISC_Monster_Type_Trait_Stacking_Effect: "${monsterType} Trait",
 
     MODIFIER_DATA_MonsterTypeTraitApplied: "Marks the affected as ${monsterType}",

--- a/src/translation/languages/chinese-traditional.ts
+++ b/src/translation/languages/chinese-traditional.ts
@@ -8,7 +8,9 @@ export const zhTW = {
     Monster_Type_Overview_Remarks_Custom_Mods_Monster_Type_Allocation: "For any monsters added through other mods, said mods have to set type definitions themselves for those monsters",
 
     Monster_Type_Overview_Player_Traits_Tab_Header: "Player traits",
-    Monster_Type_Overview_Player_Traits_Information: "Aside from organic type allocation, a type can also be forcefully applied by usage of the respective modifier, usually through equipped items or possibly shop purchase(s). This overview displays all types (and their modifier's value) currently affecting the Character. THIS DISPLAY IS STATIC, BASED ON WHEN THE CHARACTER WAS LOADED!",
+    Monster_Type_Overview_Player_Traits_Information_Type_Allocation: "Aside from organic type allocation, a type can also be forcefully applied by usage of the respective modifier, usually through equipped items or possibly shop purchase(s)",
+    Monster_Type_Overview_Player_Traits_Information_Display: "This overview displays all types (and their modifier's value) currently affecting the Character - more info may be determinable using the "Show Skill Modifiers" mod",
+    Monster_Type_Overview_Player_Traits_Information_Data_Loaded: "This display is static, based on when the character was loaded",
     Monster_Type_Overview_Player_Traits_No_Entries: "The character is not affected by any type allocation modifiers",
 
     Monster_Type_Overview_Active_Types_Tab_Header: "Active types",

--- a/src/translation/languages/chinese-traditional.ts
+++ b/src/translation/languages/chinese-traditional.ts
@@ -9,7 +9,7 @@ export const zhTW = {
 
     Monster_Type_Overview_Player_Traits_Tab_Header: "Player traits",
     Monster_Type_Overview_Player_Traits_Information_Type_Allocation: "Aside from organic type allocation, a type can also be forcefully applied by usage of the respective modifier, usually through equipped items or possibly shop purchase(s)",
-    Monster_Type_Overview_Player_Traits_Information_Display: "This overview displays all types (and their modifier's value) currently affecting the Character - more info may be determinable using the "Show Skill Modifiers" mod",
+    Monster_Type_Overview_Player_Traits_Information_Display: 'This overview displays all types (and the value of the modifier) currently affecting the Character - more info may be determinable using the "Show Skill Modifiers" mod',
     Monster_Type_Overview_Player_Traits_Information_Data_Loaded: "This display is static, based on when the character was loaded",
     Monster_Type_Overview_Player_Traits_No_Entries: "The character is not affected by any type allocation modifiers",
 
@@ -122,6 +122,8 @@ export const zhTW = {
     MONSTER_TYPE_PLURAL_SeaCreature: "Sea Creatures",
     MONSTER_TYPE_SINGULAR_Undead: "Undead",
     MONSTER_TYPE_PLURAL_Undead: "Undead",
+
+    COMBAT_MISC_Monster_Type_Trait_Effect: "${monsterType} Trait",
 
     MODIFIER_DATA_MonsterTypeTraitApplied: "Marks the affected as ${monsterType}",
     MODIFIER_DATA_increasedDamageAgainstMonsterType: "+${value}% Damage To ${monsterType}",

--- a/src/translation/languages/chinese-traditional.ts
+++ b/src/translation/languages/chinese-traditional.ts
@@ -124,6 +124,7 @@ export const zhTW = {
     MONSTER_TYPE_PLURAL_Undead: "Undead",
 
     COMBAT_MISC_Monster_Type_Trait_Effect: "${monsterType} Trait",
+    COMBAT_MISC_Monster_Type_Trait_Stacking_Effect: "${monsterType} Trait",
 
     MODIFIER_DATA_MonsterTypeTraitApplied: "Marks the affected as ${monsterType}",
     MODIFIER_DATA_increasedDamageAgainstMonsterType: "+${value}% Damage To ${monsterType}",
@@ -142,6 +143,14 @@ export const zhTW = {
     MODIFIER_DATA_decreasedGlobalAccuracyAgainstMonsterType: '-${value}% Accuracy Rating when fighting ${monsterType}',
     MODIFIER_DATA_increasedDamageReductionAgainstMonsterType: '+${value}% Damage Reduction when fighting ${monsterType}',
     MODIFIER_DATA_decreasedDamageReductionAgainstMonsterType: '-${value}% Damage Reduction when fighting ${monsterType}',
+
+    MODIFIER_DATA_increasedChanceToApplyMonsterTypeTraitInfiniteOnSpawn: '+${value}% chance to apply ${monsterType} trait for the whole fight on spawn or revive',
+    MODIFIER_DATA_decreasedChanceToApplyMonsterTypeTraitInfiniteOnSpawn: '-${value}% chance to apply ${monsterType} trait for the whole fight on spawn or revive',
+    MODIFIER_DATA_applyMonserTypeTraitTurnsOnSpawn: "Apply ${monsterType} trait on enemy for ${value} of the enemies' turns on spawn or revive",
+
+    MODIFIER_DATA_increasedChanceToApplyMonsterTypeTrait: "+${value}% chance to apply ${monsterType} trait for one of the enemies' turns",
+    MODIFIER_DATA_decreasedChanceToApplyMonsterTypeTrait: "-${value}% chance to apply ${monsterType} trait for one of the enemies' turns",
+    MODIFIER_DATA_applyMonsterTypeTraitTurns: "Apply ${monsterType} trait on enemy for ${value} of the enemies' turns",
 
     // #### Bosses
     MODIFIER_DATA_increasedMaxHitPercentAgainstBosses: "+${value}% Max Hit when fighting bosses",

--- a/src/translation/languages/english.ts
+++ b/src/translation/languages/english.ts
@@ -9,7 +9,7 @@ export const en = {
 
     Monster_Type_Overview_Player_Traits_Tab_Header: "Player traits",
     Monster_Type_Overview_Player_Traits_Information_Type_Allocation: "Aside from organic type allocation, a type can also be forcefully applied by usage of the respective modifier, usually through equipped items or possibly shop purchase(s)",
-    Monster_Type_Overview_Player_Traits_Information_Display: "This overview displays all types (and their modifier's value) currently affecting the Character - more info may be determinable using the "Show Skill Modifiers" mod",
+    Monster_Type_Overview_Player_Traits_Information_Display: 'This overview displays all types (and the value of the modifier) currently affecting the Character - more info may be determinable using the "Show Skill Modifiers" mod',
     Monster_Type_Overview_Player_Traits_Information_Data_Loaded: "This display is static, based on when the character was loaded",
     Monster_Type_Overview_Player_Traits_No_Entries: "The character is not affected by any type allocation modifiers",
 
@@ -122,6 +122,8 @@ export const en = {
     MONSTER_TYPE_PLURAL_SeaCreature: "Sea Creatures",
     MONSTER_TYPE_SINGULAR_Undead: "Undead",
     MONSTER_TYPE_PLURAL_Undead: "Undead",
+
+    COMBAT_MISC_Monster_Type_Trait_Effect: "${monsterType} Trait",
 
     MODIFIER_DATA_MonsterTypeTraitApplied: "Marks the affected as ${monsterType}",
     MODIFIER_DATA_increasedDamageAgainstMonsterType: "+${value}% Damage To ${monsterType}",

--- a/src/translation/languages/english.ts
+++ b/src/translation/languages/english.ts
@@ -8,7 +8,9 @@ export const en = {
     Monster_Type_Overview_Remarks_Custom_Mods_Monster_Type_Allocation: "For any monsters added through other mods, said mods have to set type definitions themselves for those monsters",
 
     Monster_Type_Overview_Player_Traits_Tab_Header: "Player traits",
-    Monster_Type_Overview_Player_Traits_Information: "Aside from organic type allocation, a type can also be forcefully applied by usage of the respective modifier, usually through equipped items or possibly shop purchase(s). This overview displays all types (and their modifier's value) currently affecting the Character. THIS DISPLAY IS STATIC, BASED ON WHEN THE CHARACTER WAS LOADED!",
+    Monster_Type_Overview_Player_Traits_Information_Type_Allocation: "Aside from organic type allocation, a type can also be forcefully applied by usage of the respective modifier, usually through equipped items or possibly shop purchase(s)",
+    Monster_Type_Overview_Player_Traits_Information_Display: "This overview displays all types (and their modifier's value) currently affecting the Character - more info may be determinable using the "Show Skill Modifiers" mod",
+    Monster_Type_Overview_Player_Traits_Information_Data_Loaded: "This display is static, based on when the character was loaded",
     Monster_Type_Overview_Player_Traits_No_Entries: "The character is not affected by any type allocation modifiers",
 
     Monster_Type_Overview_Active_Types_Tab_Header: "Active types",

--- a/src/translation/languages/english.ts
+++ b/src/translation/languages/english.ts
@@ -123,7 +123,7 @@ export const en = {
     MONSTER_TYPE_SINGULAR_Undead: "Undead",
     MONSTER_TYPE_PLURAL_Undead: "Undead",
 
-    COMBAT_MISC_Monster_Type_Trait_Effect: "${monsterType} Trait",
+    COMBAT_MISC_Monster_Type_Trait_Modifier_Effect: "${monsterType} Trait",
     COMBAT_MISC_Monster_Type_Trait_Stacking_Effect: "${monsterType} Trait",
 
     MODIFIER_DATA_MonsterTypeTraitApplied: "Marks the affected as ${monsterType}",

--- a/src/translation/languages/english.ts
+++ b/src/translation/languages/english.ts
@@ -124,6 +124,7 @@ export const en = {
     MONSTER_TYPE_PLURAL_Undead: "Undead",
 
     COMBAT_MISC_Monster_Type_Trait_Effect: "${monsterType} Trait",
+    COMBAT_MISC_Monster_Type_Trait_Stacking_Effect: "${monsterType} Trait",
 
     MODIFIER_DATA_MonsterTypeTraitApplied: "Marks the affected as ${monsterType}",
     MODIFIER_DATA_increasedDamageAgainstMonsterType: "+${value}% Damage To ${monsterType}",
@@ -142,6 +143,14 @@ export const en = {
     MODIFIER_DATA_decreasedGlobalAccuracyAgainstMonsterType: '-${value}% Accuracy Rating when fighting ${monsterType}',
     MODIFIER_DATA_increasedDamageReductionAgainstMonsterType: '+${value}% Damage Reduction when fighting ${monsterType}',
     MODIFIER_DATA_decreasedDamageReductionAgainstMonsterType: '-${value}% Damage Reduction when fighting ${monsterType}',
+
+    MODIFIER_DATA_increasedChanceToApplyMonsterTypeTraitInfiniteOnSpawn: '+${value}% chance to apply ${monsterType} trait for the whole fight on spawn or revive',
+    MODIFIER_DATA_decreasedChanceToApplyMonsterTypeTraitInfiniteOnSpawn: '-${value}% chance to apply ${monsterType} trait for the whole fight on spawn or revive',
+    MODIFIER_DATA_applyMonserTypeTraitTurnsOnSpawn: "Apply ${monsterType} trait on enemy for ${value} of the enemies' turns on spawn or revive",
+
+    MODIFIER_DATA_increasedChanceToApplyMonsterTypeTrait: "+${value}% chance to apply ${monsterType} trait for one of the enemies' turns",
+    MODIFIER_DATA_decreasedChanceToApplyMonsterTypeTrait: "-${value}% chance to apply ${monsterType} trait for one of the enemies' turns",
+    MODIFIER_DATA_applyMonsterTypeTraitTurns: "Apply ${monsterType} trait on enemy for ${value} of the enemies' turns",
 
     // #### Bosses
     MODIFIER_DATA_increasedMaxHitPercentAgainstBosses: "+${value}% Max Hit when fighting bosses",

--- a/src/translation/languages/french.ts
+++ b/src/translation/languages/french.ts
@@ -123,7 +123,7 @@ export const fr = {
     MONSTER_TYPE_SINGULAR_Undead: "Undead",
     MONSTER_TYPE_PLURAL_Undead: "Undead",
 
-    COMBAT_MISC_Monster_Type_Trait_Effect: "${monsterType} Trait",
+    COMBAT_MISC_Monster_Type_Trait_Modifier_Effect: "${monsterType} Trait",
     COMBAT_MISC_Monster_Type_Trait_Stacking_Effect: "${monsterType} Trait",
 
     MODIFIER_DATA_MonsterTypeTraitApplied: "Marks the affected as ${monsterType}",

--- a/src/translation/languages/french.ts
+++ b/src/translation/languages/french.ts
@@ -8,7 +8,9 @@ export const fr = {
     Monster_Type_Overview_Remarks_Custom_Mods_Monster_Type_Allocation: "For any monsters added through other mods, said mods have to set type definitions themselves for those monsters",
 
     Monster_Type_Overview_Player_Traits_Tab_Header: "Player traits",
-    Monster_Type_Overview_Player_Traits_Information: "Aside from organic type allocation, a type can also be forcefully applied by usage of the respective modifier, usually through equipped items or possibly shop purchase(s). This overview displays all types (and their modifier's value) currently affecting the Character. THIS DISPLAY IS STATIC, BASED ON WHEN THE CHARACTER WAS LOADED!",
+    Monster_Type_Overview_Player_Traits_Information_Type_Allocation: "Aside from organic type allocation, a type can also be forcefully applied by usage of the respective modifier, usually through equipped items or possibly shop purchase(s)",
+    Monster_Type_Overview_Player_Traits_Information_Display: "This overview displays all types (and their modifier's value) currently affecting the Character - more info may be determinable using the "Show Skill Modifiers" mod",
+    Monster_Type_Overview_Player_Traits_Information_Data_Loaded: "This display is static, based on when the character was loaded",
     Monster_Type_Overview_Player_Traits_No_Entries: "The character is not affected by any type allocation modifiers",
 
     Monster_Type_Overview_Active_Types_Tab_Header: "Active types",

--- a/src/translation/languages/french.ts
+++ b/src/translation/languages/french.ts
@@ -9,7 +9,7 @@ export const fr = {
 
     Monster_Type_Overview_Player_Traits_Tab_Header: "Player traits",
     Monster_Type_Overview_Player_Traits_Information_Type_Allocation: "Aside from organic type allocation, a type can also be forcefully applied by usage of the respective modifier, usually through equipped items or possibly shop purchase(s)",
-    Monster_Type_Overview_Player_Traits_Information_Display: "This overview displays all types (and their modifier's value) currently affecting the Character - more info may be determinable using the "Show Skill Modifiers" mod",
+    Monster_Type_Overview_Player_Traits_Information_Display: 'This overview displays all types (and the value of the modifier) currently affecting the Character - more info may be determinable using the "Show Skill Modifiers" mod',
     Monster_Type_Overview_Player_Traits_Information_Data_Loaded: "This display is static, based on when the character was loaded",
     Monster_Type_Overview_Player_Traits_No_Entries: "The character is not affected by any type allocation modifiers",
 
@@ -122,6 +122,8 @@ export const fr = {
     MONSTER_TYPE_PLURAL_SeaCreature: "Sea Creatures",
     MONSTER_TYPE_SINGULAR_Undead: "Undead",
     MONSTER_TYPE_PLURAL_Undead: "Undead",
+
+    COMBAT_MISC_Monster_Type_Trait_Effect: "${monsterType} Trait",
 
     MODIFIER_DATA_MonsterTypeTraitApplied: "Marks the affected as ${monsterType}",
     MODIFIER_DATA_increasedDamageAgainstMonsterType: "+${value}% Damage To ${monsterType}",

--- a/src/translation/languages/french.ts
+++ b/src/translation/languages/french.ts
@@ -124,6 +124,7 @@ export const fr = {
     MONSTER_TYPE_PLURAL_Undead: "Undead",
 
     COMBAT_MISC_Monster_Type_Trait_Effect: "${monsterType} Trait",
+    COMBAT_MISC_Monster_Type_Trait_Stacking_Effect: "${monsterType} Trait",
 
     MODIFIER_DATA_MonsterTypeTraitApplied: "Marks the affected as ${monsterType}",
     MODIFIER_DATA_increasedDamageAgainstMonsterType: "+${value}% Damage To ${monsterType}",
@@ -142,6 +143,14 @@ export const fr = {
     MODIFIER_DATA_decreasedGlobalAccuracyAgainstMonsterType: '-${value}% Accuracy Rating when fighting ${monsterType}',
     MODIFIER_DATA_increasedDamageReductionAgainstMonsterType: '+${value}% Damage Reduction when fighting ${monsterType}',
     MODIFIER_DATA_decreasedDamageReductionAgainstMonsterType: '-${value}% Damage Reduction when fighting ${monsterType}',
+
+    MODIFIER_DATA_increasedChanceToApplyMonsterTypeTraitInfiniteOnSpawn: '+${value}% chance to apply ${monsterType} trait for the whole fight on spawn or revive',
+    MODIFIER_DATA_decreasedChanceToApplyMonsterTypeTraitInfiniteOnSpawn: '-${value}% chance to apply ${monsterType} trait for the whole fight on spawn or revive',
+    MODIFIER_DATA_applyMonserTypeTraitTurnsOnSpawn: "Apply ${monsterType} trait on enemy for ${value} of the enemies' turns on spawn or revive",
+
+    MODIFIER_DATA_increasedChanceToApplyMonsterTypeTrait: "+${value}% chance to apply ${monsterType} trait for one of the enemies' turns",
+    MODIFIER_DATA_decreasedChanceToApplyMonsterTypeTrait: "-${value}% chance to apply ${monsterType} trait for one of the enemies' turns",
+    MODIFIER_DATA_applyMonsterTypeTraitTurns: "Apply ${monsterType} trait on enemy for ${value} of the enemies' turns",
 
     // #### Bosses
     MODIFIER_DATA_increasedMaxHitPercentAgainstBosses: "+${value}% Max Hit when fighting bosses",

--- a/src/translation/languages/german.ts
+++ b/src/translation/languages/german.ts
@@ -9,6 +9,9 @@
 
     Monster_Type_Overview_Player_Traits_Tab_Header: "Spieler-Modifikatoren",
     Monster_Type_Overview_Player_Traits_Information: "Neben der organischen Artenzuweisung, kann eine Art auch durch die Verwendung des jeweiligen Modifikators erzwungen werden - in der Regel durch ausgerüstete Gegenstände, oder ggf. Einkäufe im Laden. Diese Übersicht zeigt alle Arten (und den Wert ihres jeweiligen Modifikators) an, welche den Charakter derzeit beeinflussen. DIESE ANZEIGE IST STATISCH, BASIEREND AUF DEM STAND ALS DER CHARAKTER GELADEN WURDE!",
+    Monster_Type_Overview_Player_Traits_Information_Type_Allocation: "Neben der organischen Artenzuweisung, kann eine Art auch durch die Verwendung des jeweiligen Modifikators erzwungen werden - in der Regel durch ausgerüstete Gegenstände, oder ggf. Einkäufe im Laden",
+    Monster_Type_Overview_Player_Traits_Information_Display: 'Diese Übersicht zeigt alle Arten (und den Wert ihres jeweiligen Modifikators) an, welche den Charakter derzeit beeinflussen - genauere Info ist ggf. durch den "Show Skill Modifiers" herausfindbar',
+    Monster_Type_Overview_Player_Traits_Information_Data_Loaded: "Diese Anzeige ist statisch, basierend auf dem Stand als der Charakter geladen wurde",
     Monster_Type_Overview_Player_Traits_No_Entries: "Der Charakter wird derzeit nicht von Artenzuweisung beeinflusst",
 
     Monster_Type_Overview_Active_Types_Tab_Header: "Aktive Arten",

--- a/src/translation/languages/german.ts
+++ b/src/translation/languages/german.ts
@@ -127,6 +127,8 @@
     MONSTER_TYPE_SINGULAR_Undead: "Untoter",
     MONSTER_TYPE_PLURAL_Undead: "Untote",
 
+    COMBAT_MISC_Monster_Type_Trait_Effect: "${monsterType}-Merkmal",
+
     MODIFIER_DATA_MonsterTypeTraitApplied: "Markiert den Betroffenen als ${monsterType}",
     MODIFIER_DATA_increasedDamageAgainstMonsterType: "+${value}% Schaden gegen ${monsterType}",
     MODIFIER_DATA_decreasedDamageAgainstMonsterType: "-${value}% Schaden gegen ${monsterType}",

--- a/src/translation/languages/german.ts
+++ b/src/translation/languages/german.ts
@@ -101,6 +101,8 @@
     MODIFIER_DATA_decreasedMinHitBasedOnMaxHitToSlayerTasks: "-${value}% Minimalschaden bei Berserker-Aufträgen",
     MODIFIER_DATA_increasedFlatMinHitToSlayerTasks: "+${value} Minimalschaden bei Berserker-Aufträgen",
     MODIFIER_DATA_decreasedFlatMinHitToSlayerTasks: "-${value} Minimalschaden bei Berserker-Aufträgen",
+    MODIFIER_DATA_increasedGlobalAccuracyAgainstSlayerTasks: '+${value}% Genauigkeit bei Berserker-Aufträgen',
+    MODIFIER_DATA_decreasedGlobalAccuracyAgainstSlayerTasks: '-${value}% Genauigkeit bei Berserker-Aufträgen',
     MODIFIER_DATA_decreasedDamageReductionAgainstSlayerTasks: '-${value}% Schadensreduzierung bei Berserker-Aufträgen',
 
     // #### Trait application modifiers (aka "treated as type")
@@ -127,7 +129,8 @@
     MONSTER_TYPE_SINGULAR_Undead: "Untoter",
     MONSTER_TYPE_PLURAL_Undead: "Untote",
 
-    COMBAT_MISC_Monster_Type_Trait_Effect: "${monsterType}-Merkmal",
+    COMBAT_MISC_Monster_Type_Trait_Modifier_Effect: "${monsterType}-Merkmal",
+    COMBAT_MISC_Monster_Type_Trait_Stacking_Effect: "${monsterType}-Merkmal",
 
     MODIFIER_DATA_MonsterTypeTraitApplied: "Markiert den Betroffenen als ${monsterType}",
     MODIFIER_DATA_increasedDamageAgainstMonsterType: "+${value}% Schaden gegen ${monsterType}",
@@ -146,6 +149,14 @@
     MODIFIER_DATA_decreasedGlobalAccuracyAgainstMonsterType: '-${value}% Genauigkeit gegen ${monsterType}',
     MODIFIER_DATA_increasedDamageReductionAgainstMonsterType: '+${value}% Schadensreduzierung gegen ${monsterType}',
     MODIFIER_DATA_decreasedDamageReductionAgainstMonsterType: '-${value}% Schadensreduzierung gegen ${monsterType}',
+
+    MODIFIER_DATA_increasedChanceToApplyMonsterTypeTraitInfiniteOnSpawn: 'Beim Erscheinen oder der Wiederbelebung, +${value}% Chance, dass das Merkmal ${monsterType} bis zum Ende des Kampf beim Gegner angewendet wird',
+    MODIFIER_DATA_decreasedChanceToApplyMonsterTypeTraitInfiniteOnSpawn: 'Beim Erscheinen oder der Wiederbelebung, -${value}% Chance, dass das Merkmal ${monsterType} bis zum Ende des Kampf beim Gegner angewendet wird',
+    MODIFIER_DATA_applyMonserTypeTraitTurnsOnSpawn: "Beim Erscheinen oder der Wiederbelebung, wendet das Merkmal ${monsterType} für ${value} Runden des Gegners bei diesem an",
+
+    MODIFIER_DATA_increasedChanceToApplyMonsterTypeTrait: "+${value}% Chance das Merkmal ${monsterType} für eine Runde des Gegners bei diesem anzuwenden",
+    MODIFIER_DATA_decreasedChanceToApplyMonsterTypeTrait: "-${value}% Chance das Merkmal ${monsterType} für eine Runde des Gegners bei diesem anzuwenden",
+    MODIFIER_DATA_applyMonsterTypeTraitTurns: "Wendet das Merkmal ${monsterType} für ${value} Runden des Gegners bei diesem an",
 
     // #### Bosses
     MODIFIER_DATA_increasedMaxHitPercentAgainstBosses: "+${value}% Maximalschaden gegen Bosse",

--- a/src/translation/languages/italian.ts
+++ b/src/translation/languages/italian.ts
@@ -9,7 +9,7 @@ export const it = {
 
     Monster_Type_Overview_Player_Traits_Tab_Header: "Player traits",
     Monster_Type_Overview_Player_Traits_Information_Type_Allocation: "Aside from organic type allocation, a type can also be forcefully applied by usage of the respective modifier, usually through equipped items or possibly shop purchase(s)",
-    Monster_Type_Overview_Player_Traits_Information_Display: "This overview displays all types (and their modifier's value) currently affecting the Character - more info may be determinable using the "Show Skill Modifiers" mod",
+    Monster_Type_Overview_Player_Traits_Information_Display: 'This overview displays all types (and the value of the modifier) currently affecting the Character - more info may be determinable using the "Show Skill Modifiers" mod',
     Monster_Type_Overview_Player_Traits_Information_Data_Loaded: "This display is static, based on when the character was loaded",
     Monster_Type_Overview_Player_Traits_No_Entries: "The character is not affected by any type allocation modifiers",
 
@@ -122,6 +122,8 @@ export const it = {
     MONSTER_TYPE_PLURAL_SeaCreature: "Sea Creatures",
     MONSTER_TYPE_SINGULAR_Undead: "Undead",
     MONSTER_TYPE_PLURAL_Undead: "Undead",
+
+    COMBAT_MISC_Monster_Type_Trait_Effect: "${monsterType} Trait",
 
     MODIFIER_DATA_MonsterTypeTraitApplied: "Marks the affected as ${monsterType}",
     MODIFIER_DATA_increasedDamageAgainstMonsterType: "+${value}% Damage To ${monsterType}",

--- a/src/translation/languages/italian.ts
+++ b/src/translation/languages/italian.ts
@@ -123,7 +123,7 @@ export const it = {
     MONSTER_TYPE_SINGULAR_Undead: "Undead",
     MONSTER_TYPE_PLURAL_Undead: "Undead",
 
-    COMBAT_MISC_Monster_Type_Trait_Effect: "${monsterType} Trait",
+    COMBAT_MISC_Monster_Type_Trait_Modifier_Effect: "${monsterType} Trait",
     COMBAT_MISC_Monster_Type_Trait_Stacking_Effect: "${monsterType} Trait",
 
     MODIFIER_DATA_MonsterTypeTraitApplied: "Marks the affected as ${monsterType}",

--- a/src/translation/languages/italian.ts
+++ b/src/translation/languages/italian.ts
@@ -8,7 +8,9 @@ export const it = {
     Monster_Type_Overview_Remarks_Custom_Mods_Monster_Type_Allocation: "For any monsters added through other mods, said mods have to set type definitions themselves for those monsters",
 
     Monster_Type_Overview_Player_Traits_Tab_Header: "Player traits",
-    Monster_Type_Overview_Player_Traits_Information: "Aside from organic type allocation, a type can also be forcefully applied by usage of the respective modifier, usually through equipped items or possibly shop purchase(s). This overview displays all types (and their modifier's value) currently affecting the Character. THIS DISPLAY IS STATIC, BASED ON WHEN THE CHARACTER WAS LOADED!",
+    Monster_Type_Overview_Player_Traits_Information_Type_Allocation: "Aside from organic type allocation, a type can also be forcefully applied by usage of the respective modifier, usually through equipped items or possibly shop purchase(s)",
+    Monster_Type_Overview_Player_Traits_Information_Display: "This overview displays all types (and their modifier's value) currently affecting the Character - more info may be determinable using the "Show Skill Modifiers" mod",
+    Monster_Type_Overview_Player_Traits_Information_Data_Loaded: "This display is static, based on when the character was loaded",
     Monster_Type_Overview_Player_Traits_No_Entries: "The character is not affected by any type allocation modifiers",
 
     Monster_Type_Overview_Active_Types_Tab_Header: "Active types",

--- a/src/translation/languages/italian.ts
+++ b/src/translation/languages/italian.ts
@@ -124,6 +124,7 @@ export const it = {
     MONSTER_TYPE_PLURAL_Undead: "Undead",
 
     COMBAT_MISC_Monster_Type_Trait_Effect: "${monsterType} Trait",
+    COMBAT_MISC_Monster_Type_Trait_Stacking_Effect: "${monsterType} Trait",
 
     MODIFIER_DATA_MonsterTypeTraitApplied: "Marks the affected as ${monsterType}",
     MODIFIER_DATA_increasedDamageAgainstMonsterType: "+${value}% Damage To ${monsterType}",
@@ -142,6 +143,14 @@ export const it = {
     MODIFIER_DATA_decreasedGlobalAccuracyAgainstMonsterType: '-${value}% Accuracy Rating when fighting ${monsterType}',
     MODIFIER_DATA_increasedDamageReductionAgainstMonsterType: '+${value}% Damage Reduction when fighting ${monsterType}',
     MODIFIER_DATA_decreasedDamageReductionAgainstMonsterType: '-${value}% Damage Reduction when fighting ${monsterType}',
+
+    MODIFIER_DATA_increasedChanceToApplyMonsterTypeTraitInfiniteOnSpawn: '+${value}% chance to apply ${monsterType} trait for the whole fight on spawn or revive',
+    MODIFIER_DATA_decreasedChanceToApplyMonsterTypeTraitInfiniteOnSpawn: '-${value}% chance to apply ${monsterType} trait for the whole fight on spawn or revive',
+    MODIFIER_DATA_applyMonserTypeTraitTurnsOnSpawn: "Apply ${monsterType} trait on enemy for ${value} of the enemies' turns on spawn or revive",
+
+    MODIFIER_DATA_increasedChanceToApplyMonsterTypeTrait: "+${value}% chance to apply ${monsterType} trait for one of the enemies' turns",
+    MODIFIER_DATA_decreasedChanceToApplyMonsterTypeTrait: "-${value}% chance to apply ${monsterType} trait for one of the enemies' turns",
+    MODIFIER_DATA_applyMonsterTypeTraitTurns: "Apply ${monsterType} trait on enemy for ${value} of the enemies' turns",
 
     // #### Bosses
     MODIFIER_DATA_increasedMaxHitPercentAgainstBosses: "+${value}% Max Hit when fighting bosses",

--- a/src/translation/languages/japanese.ts
+++ b/src/translation/languages/japanese.ts
@@ -8,7 +8,9 @@ export const ja = {
     Monster_Type_Overview_Remarks_Custom_Mods_Monster_Type_Allocation: "For any monsters added through other mods, said mods have to set type definitions themselves for those monsters",
 
     Monster_Type_Overview_Player_Traits_Tab_Header: "Player traits",
-    Monster_Type_Overview_Player_Traits_Information: "Aside from organic type allocation, a type can also be forcefully applied by usage of the respective modifier, usually through equipped items or possibly shop purchase(s). This overview displays all types (and their modifier's value) currently affecting the Character. THIS DISPLAY IS STATIC, BASED ON WHEN THE CHARACTER WAS LOADED!",
+    Monster_Type_Overview_Player_Traits_Information_Type_Allocation: "Aside from organic type allocation, a type can also be forcefully applied by usage of the respective modifier, usually through equipped items or possibly shop purchase(s)",
+    Monster_Type_Overview_Player_Traits_Information_Display: "This overview displays all types (and their modifier's value) currently affecting the Character - more info may be determinable using the "Show Skill Modifiers" mod",
+    Monster_Type_Overview_Player_Traits_Information_Data_Loaded: "This display is static, based on when the character was loaded",
     Monster_Type_Overview_Player_Traits_No_Entries: "The character is not affected by any type allocation modifiers",
 
     Monster_Type_Overview_Active_Types_Tab_Header: "Active types",

--- a/src/translation/languages/japanese.ts
+++ b/src/translation/languages/japanese.ts
@@ -124,6 +124,7 @@ export const ja = {
     MONSTER_TYPE_PLURAL_Undead: "Undead",
 
     COMBAT_MISC_Monster_Type_Trait_Effect: "${monsterType} Trait",
+    COMBAT_MISC_Monster_Type_Trait_Stacking_Effect: "${monsterType} Trait",
 
     MODIFIER_DATA_MonsterTypeTraitApplied: "Marks the affected as ${monsterType}",
     MODIFIER_DATA_increasedDamageAgainstMonsterType: "+${value}% Damage To ${monsterType}",
@@ -142,6 +143,14 @@ export const ja = {
     MODIFIER_DATA_decreasedGlobalAccuracyAgainstMonsterType: '-${value}% Accuracy Rating when fighting ${monsterType}',
     MODIFIER_DATA_increasedDamageReductionAgainstMonsterType: '+${value}% Damage Reduction when fighting ${monsterType}',
     MODIFIER_DATA_decreasedDamageReductionAgainstMonsterType: '-${value}% Damage Reduction when fighting ${monsterType}',
+
+    MODIFIER_DATA_increasedChanceToApplyMonsterTypeTraitInfiniteOnSpawn: '+${value}% chance to apply ${monsterType} trait for the whole fight on spawn or revive',
+    MODIFIER_DATA_decreasedChanceToApplyMonsterTypeTraitInfiniteOnSpawn: '-${value}% chance to apply ${monsterType} trait for the whole fight on spawn or revive',
+    MODIFIER_DATA_applyMonserTypeTraitTurnsOnSpawn: "Apply ${monsterType} trait on enemy for ${value} of the enemies' turns on spawn or revive",
+
+    MODIFIER_DATA_increasedChanceToApplyMonsterTypeTrait: "+${value}% chance to apply ${monsterType} trait for one of the enemies' turns",
+    MODIFIER_DATA_decreasedChanceToApplyMonsterTypeTrait: "-${value}% chance to apply ${monsterType} trait for one of the enemies' turns",
+    MODIFIER_DATA_applyMonsterTypeTraitTurns: "Apply ${monsterType} trait on enemy for ${value} of the enemies' turns",
 
     // #### Bosses
     MODIFIER_DATA_increasedMaxHitPercentAgainstBosses: "+${value}% Max Hit when fighting bosses",

--- a/src/translation/languages/japanese.ts
+++ b/src/translation/languages/japanese.ts
@@ -123,7 +123,7 @@ export const ja = {
     MONSTER_TYPE_SINGULAR_Undead: "Undead",
     MONSTER_TYPE_PLURAL_Undead: "Undead",
 
-    COMBAT_MISC_Monster_Type_Trait_Effect: "${monsterType} Trait",
+    COMBAT_MISC_Monster_Type_Trait_Modifier_Effect: "${monsterType} Trait",
     COMBAT_MISC_Monster_Type_Trait_Stacking_Effect: "${monsterType} Trait",
 
     MODIFIER_DATA_MonsterTypeTraitApplied: "Marks the affected as ${monsterType}",

--- a/src/translation/languages/japanese.ts
+++ b/src/translation/languages/japanese.ts
@@ -9,7 +9,7 @@ export const ja = {
 
     Monster_Type_Overview_Player_Traits_Tab_Header: "Player traits",
     Monster_Type_Overview_Player_Traits_Information_Type_Allocation: "Aside from organic type allocation, a type can also be forcefully applied by usage of the respective modifier, usually through equipped items or possibly shop purchase(s)",
-    Monster_Type_Overview_Player_Traits_Information_Display: "This overview displays all types (and their modifier's value) currently affecting the Character - more info may be determinable using the "Show Skill Modifiers" mod",
+    Monster_Type_Overview_Player_Traits_Information_Display: 'This overview displays all types (and the value of the modifier) currently affecting the Character - more info may be determinable using the "Show Skill Modifiers" mod',
     Monster_Type_Overview_Player_Traits_Information_Data_Loaded: "This display is static, based on when the character was loaded",
     Monster_Type_Overview_Player_Traits_No_Entries: "The character is not affected by any type allocation modifiers",
 
@@ -122,6 +122,8 @@ export const ja = {
     MONSTER_TYPE_PLURAL_SeaCreature: "Sea Creatures",
     MONSTER_TYPE_SINGULAR_Undead: "Undead",
     MONSTER_TYPE_PLURAL_Undead: "Undead",
+
+    COMBAT_MISC_Monster_Type_Trait_Effect: "${monsterType} Trait",
 
     MODIFIER_DATA_MonsterTypeTraitApplied: "Marks the affected as ${monsterType}",
     MODIFIER_DATA_increasedDamageAgainstMonsterType: "+${value}% Damage To ${monsterType}",

--- a/src/translation/languages/korean.ts
+++ b/src/translation/languages/korean.ts
@@ -9,7 +9,7 @@ export const ko = {
 
     Monster_Type_Overview_Player_Traits_Tab_Header: "Player traits",
     Monster_Type_Overview_Player_Traits_Information_Type_Allocation: "Aside from organic type allocation, a type can also be forcefully applied by usage of the respective modifier, usually through equipped items or possibly shop purchase(s)",
-    Monster_Type_Overview_Player_Traits_Information_Display: "This overview displays all types (and their modifier's value) currently affecting the Character - more info may be determinable using the "Show Skill Modifiers" mod",
+    Monster_Type_Overview_Player_Traits_Information_Display: 'This overview displays all types (and the value of the modifier) currently affecting the Character - more info may be determinable using the "Show Skill Modifiers" mod',
     Monster_Type_Overview_Player_Traits_Information_Data_Loaded: "This display is static, based on when the character was loaded",
     Monster_Type_Overview_Player_Traits_No_Entries: "The character is not affected by any type allocation modifiers",
 
@@ -122,6 +122,8 @@ export const ko = {
     MONSTER_TYPE_PLURAL_SeaCreature: "Sea Creatures",
     MONSTER_TYPE_SINGULAR_Undead: "Undead",
     MONSTER_TYPE_PLURAL_Undead: "Undead",
+
+    COMBAT_MISC_Monster_Type_Trait_Effect: "${monsterType} Trait",
 
     MODIFIER_DATA_MonsterTypeTraitApplied: "Marks the affected as ${monsterType}",
     MODIFIER_DATA_increasedDamageAgainstMonsterType: "+${value}% Damage To ${monsterType}",

--- a/src/translation/languages/korean.ts
+++ b/src/translation/languages/korean.ts
@@ -123,7 +123,7 @@ export const ko = {
     MONSTER_TYPE_SINGULAR_Undead: "Undead",
     MONSTER_TYPE_PLURAL_Undead: "Undead",
 
-    COMBAT_MISC_Monster_Type_Trait_Effect: "${monsterType} Trait",
+    COMBAT_MISC_Monster_Type_Trait_Modifier_Effect: "${monsterType} Trait",
     COMBAT_MISC_Monster_Type_Trait_Stacking_Effect: "${monsterType} Trait",
 
     MODIFIER_DATA_MonsterTypeTraitApplied: "Marks the affected as ${monsterType}",

--- a/src/translation/languages/korean.ts
+++ b/src/translation/languages/korean.ts
@@ -8,7 +8,9 @@ export const ko = {
     Monster_Type_Overview_Remarks_Custom_Mods_Monster_Type_Allocation: "For any monsters added through other mods, said mods have to set type definitions themselves for those monsters",
 
     Monster_Type_Overview_Player_Traits_Tab_Header: "Player traits",
-    Monster_Type_Overview_Player_Traits_Information: "Aside from organic type allocation, a type can also be forcefully applied by usage of the respective modifier, usually through equipped items or possibly shop purchase(s). This overview displays all types (and their modifier's value) currently affecting the Character. THIS DISPLAY IS STATIC, BASED ON WHEN THE CHARACTER WAS LOADED!",
+    Monster_Type_Overview_Player_Traits_Information_Type_Allocation: "Aside from organic type allocation, a type can also be forcefully applied by usage of the respective modifier, usually through equipped items or possibly shop purchase(s)",
+    Monster_Type_Overview_Player_Traits_Information_Display: "This overview displays all types (and their modifier's value) currently affecting the Character - more info may be determinable using the "Show Skill Modifiers" mod",
+    Monster_Type_Overview_Player_Traits_Information_Data_Loaded: "This display is static, based on when the character was loaded",
     Monster_Type_Overview_Player_Traits_No_Entries: "The character is not affected by any type allocation modifiers",
 
     Monster_Type_Overview_Active_Types_Tab_Header: "Active types",

--- a/src/translation/languages/korean.ts
+++ b/src/translation/languages/korean.ts
@@ -124,6 +124,7 @@ export const ko = {
     MONSTER_TYPE_PLURAL_Undead: "Undead",
 
     COMBAT_MISC_Monster_Type_Trait_Effect: "${monsterType} Trait",
+    COMBAT_MISC_Monster_Type_Trait_Stacking_Effect: "${monsterType} Trait",
 
     MODIFIER_DATA_MonsterTypeTraitApplied: "Marks the affected as ${monsterType}",
     MODIFIER_DATA_increasedDamageAgainstMonsterType: "+${value}% Damage To ${monsterType}",
@@ -142,6 +143,14 @@ export const ko = {
     MODIFIER_DATA_decreasedGlobalAccuracyAgainstMonsterType: '-${value}% Accuracy Rating when fighting ${monsterType}',
     MODIFIER_DATA_increasedDamageReductionAgainstMonsterType: '+${value}% Damage Reduction when fighting ${monsterType}',
     MODIFIER_DATA_decreasedDamageReductionAgainstMonsterType: '-${value}% Damage Reduction when fighting ${monsterType}',
+
+    MODIFIER_DATA_increasedChanceToApplyMonsterTypeTraitInfiniteOnSpawn: '+${value}% chance to apply ${monsterType} trait for the whole fight on spawn or revive',
+    MODIFIER_DATA_decreasedChanceToApplyMonsterTypeTraitInfiniteOnSpawn: '-${value}% chance to apply ${monsterType} trait for the whole fight on spawn or revive',
+    MODIFIER_DATA_applyMonserTypeTraitTurnsOnSpawn: "Apply ${monsterType} trait on enemy for ${value} of the enemies' turns on spawn or revive",
+
+    MODIFIER_DATA_increasedChanceToApplyMonsterTypeTrait: "+${value}% chance to apply ${monsterType} trait for one of the enemies' turns",
+    MODIFIER_DATA_decreasedChanceToApplyMonsterTypeTrait: "-${value}% chance to apply ${monsterType} trait for one of the enemies' turns",
+    MODIFIER_DATA_applyMonsterTypeTraitTurns: "Apply ${monsterType} trait on enemy for ${value} of the enemies' turns",
 
     // #### Bosses
     MODIFIER_DATA_increasedMaxHitPercentAgainstBosses: "+${value}% Max Hit when fighting bosses",

--- a/src/translation/languages/portuguese-brasil.ts
+++ b/src/translation/languages/portuguese-brasil.ts
@@ -8,7 +8,9 @@ export const ptBR = {
     Monster_Type_Overview_Remarks_Custom_Mods_Monster_Type_Allocation: "For any monsters added through other mods, said mods have to set type definitions themselves for those monsters",
 
     Monster_Type_Overview_Player_Traits_Tab_Header: "Player traits",
-    Monster_Type_Overview_Player_Traits_Information: "Aside from organic type allocation, a type can also be forcefully applied by usage of the respective modifier, usually through equipped items or possibly shop purchase(s). This overview displays all types (and their modifier's value) currently affecting the Character. THIS DISPLAY IS STATIC, BASED ON WHEN THE CHARACTER WAS LOADED!",
+    Monster_Type_Overview_Player_Traits_Information_Type_Allocation: "Aside from organic type allocation, a type can also be forcefully applied by usage of the respective modifier, usually through equipped items or possibly shop purchase(s)",
+    Monster_Type_Overview_Player_Traits_Information_Display: "This overview displays all types (and their modifier's value) currently affecting the Character - more info may be determinable using the "Show Skill Modifiers" mod",
+    Monster_Type_Overview_Player_Traits_Information_Data_Loaded: "This display is static, based on when the character was loaded",
     Monster_Type_Overview_Player_Traits_No_Entries: "The character is not affected by any type allocation modifiers",
 
     Monster_Type_Overview_Active_Types_Tab_Header: "Active types",

--- a/src/translation/languages/portuguese-brasil.ts
+++ b/src/translation/languages/portuguese-brasil.ts
@@ -123,7 +123,7 @@ export const ptBR = {
     MONSTER_TYPE_SINGULAR_Undead: "Undead",
     MONSTER_TYPE_PLURAL_Undead: "Undead",
 
-    COMBAT_MISC_Monster_Type_Trait_Effect: "${monsterType} Trait",
+    COMBAT_MISC_Monster_Type_Trait_Modifier_Effect: "${monsterType} Trait",
     COMBAT_MISC_Monster_Type_Trait_Stacking_Effect: "${monsterType} Trait",
 
     MODIFIER_DATA_MonsterTypeTraitApplied: "Marks the affected as ${monsterType}",

--- a/src/translation/languages/portuguese-brasil.ts
+++ b/src/translation/languages/portuguese-brasil.ts
@@ -9,7 +9,7 @@ export const ptBR = {
 
     Monster_Type_Overview_Player_Traits_Tab_Header: "Player traits",
     Monster_Type_Overview_Player_Traits_Information_Type_Allocation: "Aside from organic type allocation, a type can also be forcefully applied by usage of the respective modifier, usually through equipped items or possibly shop purchase(s)",
-    Monster_Type_Overview_Player_Traits_Information_Display: "This overview displays all types (and their modifier's value) currently affecting the Character - more info may be determinable using the "Show Skill Modifiers" mod",
+    Monster_Type_Overview_Player_Traits_Information_Display: 'This overview displays all types (and the value of the modifier) currently affecting the Character - more info may be determinable using the "Show Skill Modifiers" mod',
     Monster_Type_Overview_Player_Traits_Information_Data_Loaded: "This display is static, based on when the character was loaded",
     Monster_Type_Overview_Player_Traits_No_Entries: "The character is not affected by any type allocation modifiers",
 
@@ -122,6 +122,8 @@ export const ptBR = {
     MONSTER_TYPE_PLURAL_SeaCreature: "Sea Creatures",
     MONSTER_TYPE_SINGULAR_Undead: "Undead",
     MONSTER_TYPE_PLURAL_Undead: "Undead",
+
+    COMBAT_MISC_Monster_Type_Trait_Effect: "${monsterType} Trait",
 
     MODIFIER_DATA_MonsterTypeTraitApplied: "Marks the affected as ${monsterType}",
     MODIFIER_DATA_increasedDamageAgainstMonsterType: "+${value}% Damage To ${monsterType}",

--- a/src/translation/languages/portuguese-brasil.ts
+++ b/src/translation/languages/portuguese-brasil.ts
@@ -124,6 +124,7 @@ export const ptBR = {
     MONSTER_TYPE_PLURAL_Undead: "Undead",
 
     COMBAT_MISC_Monster_Type_Trait_Effect: "${monsterType} Trait",
+    COMBAT_MISC_Monster_Type_Trait_Stacking_Effect: "${monsterType} Trait",
 
     MODIFIER_DATA_MonsterTypeTraitApplied: "Marks the affected as ${monsterType}",
     MODIFIER_DATA_increasedDamageAgainstMonsterType: "+${value}% Damage To ${monsterType}",
@@ -142,6 +143,14 @@ export const ptBR = {
     MODIFIER_DATA_decreasedGlobalAccuracyAgainstMonsterType: '-${value}% Accuracy Rating when fighting ${monsterType}',
     MODIFIER_DATA_increasedDamageReductionAgainstMonsterType: '+${value}% Damage Reduction when fighting ${monsterType}',
     MODIFIER_DATA_decreasedDamageReductionAgainstMonsterType: '-${value}% Damage Reduction when fighting ${monsterType}',
+
+    MODIFIER_DATA_increasedChanceToApplyMonsterTypeTraitInfiniteOnSpawn: '+${value}% chance to apply ${monsterType} trait for the whole fight on spawn or revive',
+    MODIFIER_DATA_decreasedChanceToApplyMonsterTypeTraitInfiniteOnSpawn: '-${value}% chance to apply ${monsterType} trait for the whole fight on spawn or revive',
+    MODIFIER_DATA_applyMonserTypeTraitTurnsOnSpawn: "Apply ${monsterType} trait on enemy for ${value} of the enemies' turns on spawn or revive",
+
+    MODIFIER_DATA_increasedChanceToApplyMonsterTypeTrait: "+${value}% chance to apply ${monsterType} trait for one of the enemies' turns",
+    MODIFIER_DATA_decreasedChanceToApplyMonsterTypeTrait: "-${value}% chance to apply ${monsterType} trait for one of the enemies' turns",
+    MODIFIER_DATA_applyMonsterTypeTraitTurns: "Apply ${monsterType} trait on enemy for ${value} of the enemies' turns",
 
     // #### Bosses
     MODIFIER_DATA_increasedMaxHitPercentAgainstBosses: "+${value}% Max Hit when fighting bosses",

--- a/src/translation/languages/portuguese.ts
+++ b/src/translation/languages/portuguese.ts
@@ -8,7 +8,9 @@ export const pt = {
     Monster_Type_Overview_Remarks_Custom_Mods_Monster_Type_Allocation: "For any monsters added through other mods, said mods have to set type definitions themselves for those monsters",
 
     Monster_Type_Overview_Player_Traits_Tab_Header: "Player traits",
-    Monster_Type_Overview_Player_Traits_Information: "Aside from organic type allocation, a type can also be forcefully applied by usage of the respective modifier, usually through equipped items or possibly shop purchase(s). This overview displays all types (and their modifier's value) currently affecting the Character. THIS DISPLAY IS STATIC, BASED ON WHEN THE CHARACTER WAS LOADED!",
+    Monster_Type_Overview_Player_Traits_Information_Type_Allocation: "Aside from organic type allocation, a type can also be forcefully applied by usage of the respective modifier, usually through equipped items or possibly shop purchase(s)",
+    Monster_Type_Overview_Player_Traits_Information_Display: "This overview displays all types (and their modifier's value) currently affecting the Character - more info may be determinable using the "Show Skill Modifiers" mod",
+    Monster_Type_Overview_Player_Traits_Information_Data_Loaded: "This display is static, based on when the character was loaded",
     Monster_Type_Overview_Player_Traits_No_Entries: "The character is not affected by any type allocation modifiers",
 
     Monster_Type_Overview_Active_Types_Tab_Header: "Active types",

--- a/src/translation/languages/portuguese.ts
+++ b/src/translation/languages/portuguese.ts
@@ -123,7 +123,7 @@ export const pt = {
     MONSTER_TYPE_SINGULAR_Undead: "Undead",
     MONSTER_TYPE_PLURAL_Undead: "Undead",
 
-    COMBAT_MISC_Monster_Type_Trait_Effect: "${monsterType} Trait",
+    COMBAT_MISC_Monster_Type_Trait_Modifier_Effect: "${monsterType} Trait",
     COMBAT_MISC_Monster_Type_Trait_Stacking_Effect: "${monsterType} Trait",
 
     MODIFIER_DATA_MonsterTypeTraitApplied: "Marks the affected as ${monsterType}",

--- a/src/translation/languages/portuguese.ts
+++ b/src/translation/languages/portuguese.ts
@@ -124,6 +124,7 @@ export const pt = {
     MONSTER_TYPE_PLURAL_Undead: "Undead",
 
     COMBAT_MISC_Monster_Type_Trait_Effect: "${monsterType} Trait",
+    COMBAT_MISC_Monster_Type_Trait_Stacking_Effect: "${monsterType} Trait",
 
     MODIFIER_DATA_MonsterTypeTraitApplied: "Marks the affected as ${monsterType}",
     MODIFIER_DATA_increasedDamageAgainstMonsterType: "+${value}% Damage To ${monsterType}",
@@ -142,6 +143,14 @@ export const pt = {
     MODIFIER_DATA_decreasedGlobalAccuracyAgainstMonsterType: '-${value}% Accuracy Rating when fighting ${monsterType}',
     MODIFIER_DATA_increasedDamageReductionAgainstMonsterType: '+${value}% Damage Reduction when fighting ${monsterType}',
     MODIFIER_DATA_decreasedDamageReductionAgainstMonsterType: '-${value}% Damage Reduction when fighting ${monsterType}',
+
+    MODIFIER_DATA_increasedChanceToApplyMonsterTypeTraitInfiniteOnSpawn: '+${value}% chance to apply ${monsterType} trait for the whole fight on spawn or revive',
+    MODIFIER_DATA_decreasedChanceToApplyMonsterTypeTraitInfiniteOnSpawn: '-${value}% chance to apply ${monsterType} trait for the whole fight on spawn or revive',
+    MODIFIER_DATA_applyMonserTypeTraitTurnsOnSpawn: "Apply ${monsterType} trait on enemy for ${value} of the enemies' turns on spawn or revive",
+
+    MODIFIER_DATA_increasedChanceToApplyMonsterTypeTrait: "+${value}% chance to apply ${monsterType} trait for one of the enemies' turns",
+    MODIFIER_DATA_decreasedChanceToApplyMonsterTypeTrait: "-${value}% chance to apply ${monsterType} trait for one of the enemies' turns",
+    MODIFIER_DATA_applyMonsterTypeTraitTurns: "Apply ${monsterType} trait on enemy for ${value} of the enemies' turns",
 
     // #### Bosses
     MODIFIER_DATA_increasedMaxHitPercentAgainstBosses: "+${value}% Max Hit when fighting bosses",

--- a/src/translation/languages/portuguese.ts
+++ b/src/translation/languages/portuguese.ts
@@ -9,7 +9,7 @@ export const pt = {
 
     Monster_Type_Overview_Player_Traits_Tab_Header: "Player traits",
     Monster_Type_Overview_Player_Traits_Information_Type_Allocation: "Aside from organic type allocation, a type can also be forcefully applied by usage of the respective modifier, usually through equipped items or possibly shop purchase(s)",
-    Monster_Type_Overview_Player_Traits_Information_Display: "This overview displays all types (and their modifier's value) currently affecting the Character - more info may be determinable using the "Show Skill Modifiers" mod",
+    Monster_Type_Overview_Player_Traits_Information_Display: 'This overview displays all types (and the value of the modifier) currently affecting the Character - more info may be determinable using the "Show Skill Modifiers" mod',
     Monster_Type_Overview_Player_Traits_Information_Data_Loaded: "This display is static, based on when the character was loaded",
     Monster_Type_Overview_Player_Traits_No_Entries: "The character is not affected by any type allocation modifiers",
 
@@ -122,6 +122,8 @@ export const pt = {
     MONSTER_TYPE_PLURAL_SeaCreature: "Sea Creatures",
     MONSTER_TYPE_SINGULAR_Undead: "Undead",
     MONSTER_TYPE_PLURAL_Undead: "Undead",
+
+    COMBAT_MISC_Monster_Type_Trait_Effect: "${monsterType} Trait",
 
     MODIFIER_DATA_MonsterTypeTraitApplied: "Marks the affected as ${monsterType}",
     MODIFIER_DATA_increasedDamageAgainstMonsterType: "+${value}% Damage To ${monsterType}",

--- a/src/translation/languages/russian.ts
+++ b/src/translation/languages/russian.ts
@@ -9,7 +9,7 @@ export const ru = {
 
     Monster_Type_Overview_Player_Traits_Tab_Header: "Player traits",
     Monster_Type_Overview_Player_Traits_Information_Type_Allocation: "Aside from organic type allocation, a type can also be forcefully applied by usage of the respective modifier, usually through equipped items or possibly shop purchase(s)",
-    Monster_Type_Overview_Player_Traits_Information_Display: "This overview displays all types (and their modifier's value) currently affecting the Character - more info may be determinable using the "Show Skill Modifiers" mod",
+    Monster_Type_Overview_Player_Traits_Information_Display: 'This overview displays all types (and the value of the modifier) currently affecting the Character - more info may be determinable using the "Show Skill Modifiers" mod',
     Monster_Type_Overview_Player_Traits_Information_Data_Loaded: "This display is static, based on when the character was loaded",
     Monster_Type_Overview_Player_Traits_No_Entries: "The character is not affected by any type allocation modifiers",
 
@@ -122,6 +122,8 @@ export const ru = {
     MONSTER_TYPE_PLURAL_SeaCreature: "Sea Creatures",
     MONSTER_TYPE_SINGULAR_Undead: "Undead",
     MONSTER_TYPE_PLURAL_Undead: "Undead",
+
+    COMBAT_MISC_Monster_Type_Trait_Effect: "${monsterType} Trait",
 
     MODIFIER_DATA_MonsterTypeTraitApplied: "Marks the affected as ${monsterType}",
     MODIFIER_DATA_increasedDamageAgainstMonsterType: "+${value}% Damage To ${monsterType}",

--- a/src/translation/languages/russian.ts
+++ b/src/translation/languages/russian.ts
@@ -124,6 +124,7 @@ export const ru = {
     MONSTER_TYPE_PLURAL_Undead: "Undead",
 
     COMBAT_MISC_Monster_Type_Trait_Effect: "${monsterType} Trait",
+    COMBAT_MISC_Monster_Type_Trait_Stacking_Effect: "${monsterType} Trait",
 
     MODIFIER_DATA_MonsterTypeTraitApplied: "Marks the affected as ${monsterType}",
     MODIFIER_DATA_increasedDamageAgainstMonsterType: "+${value}% Damage To ${monsterType}",
@@ -142,6 +143,14 @@ export const ru = {
     MODIFIER_DATA_decreasedGlobalAccuracyAgainstMonsterType: '-${value}% Accuracy Rating when fighting ${monsterType}',
     MODIFIER_DATA_increasedDamageReductionAgainstMonsterType: '+${value}% Damage Reduction when fighting ${monsterType}',
     MODIFIER_DATA_decreasedDamageReductionAgainstMonsterType: '-${value}% Damage Reduction when fighting ${monsterType}',
+
+    MODIFIER_DATA_increasedChanceToApplyMonsterTypeTraitInfiniteOnSpawn: '+${value}% chance to apply ${monsterType} trait for the whole fight on spawn or revive',
+    MODIFIER_DATA_decreasedChanceToApplyMonsterTypeTraitInfiniteOnSpawn: '-${value}% chance to apply ${monsterType} trait for the whole fight on spawn or revive',
+    MODIFIER_DATA_applyMonserTypeTraitTurnsOnSpawn: "Apply ${monsterType} trait on enemy for ${value} of the enemies' turns on spawn or revive",
+
+    MODIFIER_DATA_increasedChanceToApplyMonsterTypeTrait: "+${value}% chance to apply ${monsterType} trait for one of the enemies' turns",
+    MODIFIER_DATA_decreasedChanceToApplyMonsterTypeTrait: "-${value}% chance to apply ${monsterType} trait for one of the enemies' turns",
+    MODIFIER_DATA_applyMonsterTypeTraitTurns: "Apply ${monsterType} trait on enemy for ${value} of the enemies' turns",
 
     // #### Bosses
     MODIFIER_DATA_increasedMaxHitPercentAgainstBosses: "+${value}% Max Hit when fighting bosses",

--- a/src/translation/languages/russian.ts
+++ b/src/translation/languages/russian.ts
@@ -123,7 +123,7 @@ export const ru = {
     MONSTER_TYPE_SINGULAR_Undead: "Undead",
     MONSTER_TYPE_PLURAL_Undead: "Undead",
 
-    COMBAT_MISC_Monster_Type_Trait_Effect: "${monsterType} Trait",
+    COMBAT_MISC_Monster_Type_Trait_Modifier_Effect: "${monsterType} Trait",
     COMBAT_MISC_Monster_Type_Trait_Stacking_Effect: "${monsterType} Trait",
 
     MODIFIER_DATA_MonsterTypeTraitApplied: "Marks the affected as ${monsterType}",

--- a/src/translation/languages/russian.ts
+++ b/src/translation/languages/russian.ts
@@ -8,7 +8,9 @@ export const ru = {
     Monster_Type_Overview_Remarks_Custom_Mods_Monster_Type_Allocation: "For any monsters added through other mods, said mods have to set type definitions themselves for those monsters",
 
     Monster_Type_Overview_Player_Traits_Tab_Header: "Player traits",
-    Monster_Type_Overview_Player_Traits_Information: "Aside from organic type allocation, a type can also be forcefully applied by usage of the respective modifier, usually through equipped items or possibly shop purchase(s). This overview displays all types (and their modifier's value) currently affecting the Character. THIS DISPLAY IS STATIC, BASED ON WHEN THE CHARACTER WAS LOADED!",
+    Monster_Type_Overview_Player_Traits_Information_Type_Allocation: "Aside from organic type allocation, a type can also be forcefully applied by usage of the respective modifier, usually through equipped items or possibly shop purchase(s)",
+    Monster_Type_Overview_Player_Traits_Information_Display: "This overview displays all types (and their modifier's value) currently affecting the Character - more info may be determinable using the "Show Skill Modifiers" mod",
+    Monster_Type_Overview_Player_Traits_Information_Data_Loaded: "This display is static, based on when the character was loaded",
     Monster_Type_Overview_Player_Traits_No_Entries: "The character is not affected by any type allocation modifiers",
 
     Monster_Type_Overview_Active_Types_Tab_Header: "Active types",

--- a/src/translation/languages/spanish.ts
+++ b/src/translation/languages/spanish.ts
@@ -9,7 +9,7 @@ export const es = {
 
     Monster_Type_Overview_Player_Traits_Tab_Header: "Player traits",
     Monster_Type_Overview_Player_Traits_Information_Type_Allocation: "Aside from organic type allocation, a type can also be forcefully applied by usage of the respective modifier, usually through equipped items or possibly shop purchase(s)",
-    Monster_Type_Overview_Player_Traits_Information_Display: "This overview displays all types (and their modifier's value) currently affecting the Character - more info may be determinable using the "Show Skill Modifiers" mod",
+    Monster_Type_Overview_Player_Traits_Information_Display: 'This overview displays all types (and the value of the modifier) currently affecting the Character - more info may be determinable using the "Show Skill Modifiers" mod',
     Monster_Type_Overview_Player_Traits_Information_Data_Loaded: "This display is static, based on when the character was loaded",
     Monster_Type_Overview_Player_Traits_No_Entries: "The character is not affected by any type allocation modifiers",
 
@@ -122,6 +122,8 @@ export const es = {
     MONSTER_TYPE_PLURAL_SeaCreature: "Sea Creatures",
     MONSTER_TYPE_SINGULAR_Undead: "Undead",
     MONSTER_TYPE_PLURAL_Undead: "Undead",
+
+    COMBAT_MISC_Monster_Type_Trait_Effect: "${monsterType} Trait",
 
     MODIFIER_DATA_MonsterTypeTraitApplied: "Marks the affected as ${monsterType}",
     MODIFIER_DATA_increasedDamageAgainstMonsterType: "+${value}% Damage To ${monsterType}",

--- a/src/translation/languages/spanish.ts
+++ b/src/translation/languages/spanish.ts
@@ -123,7 +123,7 @@ export const es = {
     MONSTER_TYPE_SINGULAR_Undead: "Undead",
     MONSTER_TYPE_PLURAL_Undead: "Undead",
 
-    COMBAT_MISC_Monster_Type_Trait_Effect: "${monsterType} Trait",
+    COMBAT_MISC_Monster_Type_Trait_Modifier_Effect: "${monsterType} Trait",
     COMBAT_MISC_Monster_Type_Trait_Stacking_Effect: "${monsterType} Trait",
 
     MODIFIER_DATA_MonsterTypeTraitApplied: "Marks the affected as ${monsterType}",

--- a/src/translation/languages/spanish.ts
+++ b/src/translation/languages/spanish.ts
@@ -124,6 +124,7 @@ export const es = {
     MONSTER_TYPE_PLURAL_Undead: "Undead",
 
     COMBAT_MISC_Monster_Type_Trait_Effect: "${monsterType} Trait",
+    COMBAT_MISC_Monster_Type_Trait_Stacking_Effect: "${monsterType} Trait",
 
     MODIFIER_DATA_MonsterTypeTraitApplied: "Marks the affected as ${monsterType}",
     MODIFIER_DATA_increasedDamageAgainstMonsterType: "+${value}% Damage To ${monsterType}",
@@ -142,6 +143,14 @@ export const es = {
     MODIFIER_DATA_decreasedGlobalAccuracyAgainstMonsterType: '-${value}% Accuracy Rating when fighting ${monsterType}',
     MODIFIER_DATA_increasedDamageReductionAgainstMonsterType: '+${value}% Damage Reduction when fighting ${monsterType}',
     MODIFIER_DATA_decreasedDamageReductionAgainstMonsterType: '-${value}% Damage Reduction when fighting ${monsterType}',
+
+    MODIFIER_DATA_increasedChanceToApplyMonsterTypeTraitInfiniteOnSpawn: '+${value}% chance to apply ${monsterType} trait for the whole fight on spawn or revive',
+    MODIFIER_DATA_decreasedChanceToApplyMonsterTypeTraitInfiniteOnSpawn: '-${value}% chance to apply ${monsterType} trait for the whole fight on spawn or revive',
+    MODIFIER_DATA_applyMonserTypeTraitTurnsOnSpawn: "Apply ${monsterType} trait on enemy for ${value} of the enemies' turns on spawn or revive",
+
+    MODIFIER_DATA_increasedChanceToApplyMonsterTypeTrait: "+${value}% chance to apply ${monsterType} trait for one of the enemies' turns",
+    MODIFIER_DATA_decreasedChanceToApplyMonsterTypeTrait: "-${value}% chance to apply ${monsterType} trait for one of the enemies' turns",
+    MODIFIER_DATA_applyMonsterTypeTraitTurns: "Apply ${monsterType} trait on enemy for ${value} of the enemies' turns",
 
     // #### Bosses
     MODIFIER_DATA_increasedMaxHitPercentAgainstBosses: "+${value}% Max Hit when fighting bosses",

--- a/src/translation/languages/spanish.ts
+++ b/src/translation/languages/spanish.ts
@@ -8,7 +8,9 @@ export const es = {
     Monster_Type_Overview_Remarks_Custom_Mods_Monster_Type_Allocation: "For any monsters added through other mods, said mods have to set type definitions themselves for those monsters",
 
     Monster_Type_Overview_Player_Traits_Tab_Header: "Player traits",
-    Monster_Type_Overview_Player_Traits_Information: "Aside from organic type allocation, a type can also be forcefully applied by usage of the respective modifier, usually through equipped items or possibly shop purchase(s). This overview displays all types (and their modifier's value) currently affecting the Character. THIS DISPLAY IS STATIC, BASED ON WHEN THE CHARACTER WAS LOADED!",
+    Monster_Type_Overview_Player_Traits_Information_Type_Allocation: "Aside from organic type allocation, a type can also be forcefully applied by usage of the respective modifier, usually through equipped items or possibly shop purchase(s)",
+    Monster_Type_Overview_Player_Traits_Information_Display: "This overview displays all types (and their modifier's value) currently affecting the Character - more info may be determinable using the "Show Skill Modifiers" mod",
+    Monster_Type_Overview_Player_Traits_Information_Data_Loaded: "This display is static, based on when the character was loaded",
     Monster_Type_Overview_Player_Traits_No_Entries: "The character is not affected by any type allocation modifiers",
 
     Monster_Type_Overview_Active_Types_Tab_Header: "Active types",

--- a/src/translation/languages/turkish.ts
+++ b/src/translation/languages/turkish.ts
@@ -123,7 +123,7 @@ export const tr = {
     MONSTER_TYPE_SINGULAR_Undead: "Undead",
     MONSTER_TYPE_PLURAL_Undead: "Undead",
 
-    COMBAT_MISC_Monster_Type_Trait_Effect: "${monsterType} Trait",
+    COMBAT_MISC_Monster_Type_Trait_Modifier_Effect: "${monsterType} Trait",
     COMBAT_MISC_Monster_Type_Trait_Stacking_Effect: "${monsterType} Trait",
 
     MODIFIER_DATA_MonsterTypeTraitApplied: "Marks the affected as ${monsterType}",

--- a/src/translation/languages/turkish.ts
+++ b/src/translation/languages/turkish.ts
@@ -8,7 +8,9 @@ export const tr = {
     Monster_Type_Overview_Remarks_Custom_Mods_Monster_Type_Allocation: "For any monsters added through other mods, said mods have to set type definitions themselves for those monsters",
 
     Monster_Type_Overview_Player_Traits_Tab_Header: "Player traits",
-    Monster_Type_Overview_Player_Traits_Information: "Aside from organic type allocation, a type can also be forcefully applied by usage of the respective modifier, usually through equipped items or possibly shop purchase(s). This overview displays all types (and their modifier's value) currently affecting the Character. THIS DISPLAY IS STATIC, BASED ON WHEN THE CHARACTER WAS LOADED!",
+    Monster_Type_Overview_Player_Traits_Information_Type_Allocation: "Aside from organic type allocation, a type can also be forcefully applied by usage of the respective modifier, usually through equipped items or possibly shop purchase(s)",
+    Monster_Type_Overview_Player_Traits_Information_Display: "This overview displays all types (and their modifier's value) currently affecting the Character - more info may be determinable using the "Show Skill Modifiers" mod",
+    Monster_Type_Overview_Player_Traits_Information_Data_Loaded: "This display is static, based on when the character was loaded",
     Monster_Type_Overview_Player_Traits_No_Entries: "The character is not affected by any type allocation modifiers",
 
     Monster_Type_Overview_Active_Types_Tab_Header: "Active types",

--- a/src/translation/languages/turkish.ts
+++ b/src/translation/languages/turkish.ts
@@ -9,7 +9,7 @@ export const tr = {
 
     Monster_Type_Overview_Player_Traits_Tab_Header: "Player traits",
     Monster_Type_Overview_Player_Traits_Information_Type_Allocation: "Aside from organic type allocation, a type can also be forcefully applied by usage of the respective modifier, usually through equipped items or possibly shop purchase(s)",
-    Monster_Type_Overview_Player_Traits_Information_Display: "This overview displays all types (and their modifier's value) currently affecting the Character - more info may be determinable using the "Show Skill Modifiers" mod",
+    Monster_Type_Overview_Player_Traits_Information_Display: 'This overview displays all types (and the value of the modifier) currently affecting the Character - more info may be determinable using the "Show Skill Modifiers" mod',
     Monster_Type_Overview_Player_Traits_Information_Data_Loaded: "This display is static, based on when the character was loaded",
     Monster_Type_Overview_Player_Traits_No_Entries: "The character is not affected by any type allocation modifiers",
 
@@ -122,6 +122,8 @@ export const tr = {
     MONSTER_TYPE_PLURAL_SeaCreature: "Sea Creatures",
     MONSTER_TYPE_SINGULAR_Undead: "Undead",
     MONSTER_TYPE_PLURAL_Undead: "Undead",
+
+    COMBAT_MISC_Monster_Type_Trait_Effect: "${monsterType} Trait",
 
     MODIFIER_DATA_MonsterTypeTraitApplied: "Marks the affected as ${monsterType}",
     MODIFIER_DATA_increasedDamageAgainstMonsterType: "+${value}% Damage To ${monsterType}",

--- a/src/translation/languages/turkish.ts
+++ b/src/translation/languages/turkish.ts
@@ -124,6 +124,7 @@ export const tr = {
     MONSTER_TYPE_PLURAL_Undead: "Undead",
 
     COMBAT_MISC_Monster_Type_Trait_Effect: "${monsterType} Trait",
+    COMBAT_MISC_Monster_Type_Trait_Stacking_Effect: "${monsterType} Trait",
 
     MODIFIER_DATA_MonsterTypeTraitApplied: "Marks the affected as ${monsterType}",
     MODIFIER_DATA_increasedDamageAgainstMonsterType: "+${value}% Damage To ${monsterType}",
@@ -142,6 +143,14 @@ export const tr = {
     MODIFIER_DATA_decreasedGlobalAccuracyAgainstMonsterType: '-${value}% Accuracy Rating when fighting ${monsterType}',
     MODIFIER_DATA_increasedDamageReductionAgainstMonsterType: '+${value}% Damage Reduction when fighting ${monsterType}',
     MODIFIER_DATA_decreasedDamageReductionAgainstMonsterType: '-${value}% Damage Reduction when fighting ${monsterType}',
+
+    MODIFIER_DATA_increasedChanceToApplyMonsterTypeTraitInfiniteOnSpawn: '+${value}% chance to apply ${monsterType} trait for the whole fight on spawn or revive',
+    MODIFIER_DATA_decreasedChanceToApplyMonsterTypeTraitInfiniteOnSpawn: '-${value}% chance to apply ${monsterType} trait for the whole fight on spawn or revive',
+    MODIFIER_DATA_applyMonserTypeTraitTurnsOnSpawn: "Apply ${monsterType} trait on enemy for ${value} of the enemies' turns on spawn or revive",
+
+    MODIFIER_DATA_increasedChanceToApplyMonsterTypeTrait: "+${value}% chance to apply ${monsterType} trait for one of the enemies' turns",
+    MODIFIER_DATA_decreasedChanceToApplyMonsterTypeTrait: "-${value}% chance to apply ${monsterType} trait for one of the enemies' turns",
+    MODIFIER_DATA_applyMonsterTypeTraitTurns: "Apply ${monsterType} trait on enemy for ${value} of the enemies' turns",
 
     // #### Bosses
     MODIFIER_DATA_increasedMaxHitPercentAgainstBosses: "+${value}% Max Hit when fighting bosses",


### PR DESCRIPTION
* Added modifiers and effects for dynamic application of trait during combat
* `registerOrUpdateType` endpoint now has a default value (`true`) for the `active` parameter